### PR TITLE
🔀 :: (#77) - QR 반응 페이지 확인 버튼을 홈 이동으로 변경

### DIFF
--- a/lib/features/qr/presentation/screens/qr_base_screen.dart
+++ b/lib/features/qr/presentation/screens/qr_base_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:goms/core/router/route_path.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
 import 'package:goms/core/theme/typography/app_text_styles.dart';
@@ -66,7 +68,7 @@ class QrBaseScreen extends StatelessWidget {
           const Spacer(),
           ConfirmButton(
             text: buttonText,
-            onPressed: onPressed ?? () => Navigator.of(context).maybePop(),
+            onPressed: onPressed ?? () => context.go(RoutePath.home),
           ),
         ],
       ),

--- a/lib/features/qr/presentation/screens/qr_base_screen.dart
+++ b/lib/features/qr/presentation/screens/qr_base_screen.dart
@@ -24,7 +24,7 @@ class QrBaseScreen extends StatelessWidget {
   /// 버튼 텍스트
   final String buttonText;
 
-  /// 버튼 콜백 (null 이면 Navigator.maybePop)
+  /// 버튼 콜백 (null 이면 홈으로 이동)
   final VoidCallback? onPressed;
 
   /// 부제목 아래에 삽입할 추가 위젯 (선택)


### PR DESCRIPTION
## 💡 개요
QR 스캔 후 반응 페이지의 확인 버튼이 이전 화면으로 돌아가지 않고 항상 홈으로 이동하도록 정리했습니다.

## 🔗 관련 이슈
Closes #77

## 📃 작업내용
- QR 반응 공통 화면의 기본 확인 버튼 동작을 뒤로가기에서 홈 이동으로 변경했습니다.
- 홈 라우트 상수를 사용하도록 수정해 스캔 진입 경로와 무관하게 동일한 종료 흐름을 보장했습니다.

## 🔍 테스트 방법
- `flutter analyze`
- `flutter test test/unit/routes_and_signup_state_unit_test.dart`

## 🖼️ 스크린샷

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 기존 기능이 정상적으로 작동하는지 확인했습니다.
