### PR TITLE
🔀 :: (#78) - 여러 화면 새로 고침 동작 정리 및 관리자 리포트 바로가기 추가

### DIFF
--- a/lib/core/network/dio_providers.dart
+++ b/lib/core/network/dio_providers.dart
@@ -15,9 +15,9 @@ final dioProvider = Provider<Dio>((ref) {
     BaseOptions(
       baseUrl: baseUrl,
       contentType: 'application/json',
-      connectTimeout: const Duration(seconds: 10),
-      receiveTimeout: const Duration(seconds: 10),
-      sendTimeout: const Duration(seconds: 10),
+      connectTimeout: const Duration(seconds: 30),
+      receiveTimeout: const Duration(seconds: 30),
+      sendTimeout: const Duration(seconds: 30),
     ),
   );
 

--- a/lib/core/widgets/common/appbar/goms_app_bar.dart
+++ b/lib/core/widgets/common/appbar/goms_app_bar.dart
@@ -97,7 +97,8 @@ class GomsAppBar extends StatelessWidget implements PreferredSizeWidget {
                   ),
                 ),
                 const Spacer(),
-                IconButton(
+                if(role == RoleEnum.admin)
+                  IconButton(
                   onPressed: () => context.push(RoutePath.studentCouncilReports),
                   icon: AppIcons.report(
                   width: 24,

--- a/lib/features/outing/presentation/screens/admin_latecomer_list_screen.dart
+++ b/lib/features/outing/presentation/screens/admin_latecomer_list_screen.dart
@@ -76,59 +76,92 @@ class _AdminLatecomerListScreenState
           ),
           AppGap.v4,
           Expanded(
-            child: lateStudents.when(
-              data: (students) {
-                if (students.isEmpty) {
-                  return Center(
-                    child: Text(
-                      '지각자가 없어요.',
-                      style: AppTextStyles.text2.copyWith(
-                        color: context.sub2Color,
-                      ),
-                    ),
-                  );
-                }
-
-                return ListView.separated(
-                  itemCount: students.length,
-                  itemBuilder: (context, index) {
-                    final member = students[index];
-                    return LateProfileListContainer(
-                      name: member.name,
-                      grade: member.grade,
-                      major: member.department,
-                    );
-                  },
-                  separatorBuilder: (context, index) {
-                    return Divider(
-                      thickness: 1,
-                      color: context.buttonColor,
-                    );
-                  },
-                );
+            child: RefreshIndicator(
+              onRefresh: () {
+                return ref
+                    .read(studentCouncilLateStudentsProvider.notifier)
+                    .reload();
               },
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, _) => Center(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      error is StudentCouncilLateStudentsException
-                          ? error.message
-                          : '지각자 명단을 불러오지 못했어요.',
-                      style: AppTextStyles.text2.copyWith(
-                        color: context.sub2Color,
-                      ),
-                      textAlign: TextAlign.center,
+              child: lateStudents.when(
+                data: (students) {
+                  if (students.isEmpty) {
+                    return ListView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      children: [
+                        SizedBox(
+                          height: 280,
+                          child: Center(
+                            child: Text(
+                              '지각자가 없어요.',
+                              style: AppTextStyles.text2.copyWith(
+                                color: context.sub2Color,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  }
+
+                  return ListView.separated(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    itemCount: students.length,
+                    itemBuilder: (context, index) {
+                      final member = students[index];
+                      return LateProfileListContainer(
+                        name: member.name,
+                        grade: member.grade,
+                        major: member.department,
+                      );
+                    },
+                    separatorBuilder: (context, index) {
+                      return Divider(
+                        thickness: 1,
+                        color: context.buttonColor,
+                      );
+                    },
+                  );
+                },
+                loading: () => ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: const [
+                    SizedBox(
+                      height: 280,
+                      child: Center(child: CircularProgressIndicator()),
                     ),
-                    AppGap.v12,
-                    TextButton(
-                      onPressed: () {
-                        ref
-                            .read(studentCouncilLateStudentsProvider.notifier)
-                            .reload();
-                      },
-                      child: const Text('다시 시도'),
+                  ],
+                ),
+                error: (error, _) => ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: [
+                    SizedBox(
+                      height: 280,
+                      child: Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              error is StudentCouncilLateStudentsException
+                                  ? error.message
+                                  : '지각자 명단을 불러오지 못했어요.',
+                              style: AppTextStyles.text2.copyWith(
+                                color: context.sub2Color,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                            AppGap.v12,
+                            TextButton(
+                              onPressed: () {
+                                ref
+                                    .read(studentCouncilLateStudentsProvider
+                                        .notifier,)
+                                    .reload();
+                              },
+                              child: const Text('다시 시도'),
+                            ),
+                          ],
+                        ),
+                      ),
                     ),
                   ],
                 ),

--- a/lib/features/outing/presentation/screens/admin_outing_state_screen.dart
+++ b/lib/features/outing/presentation/screens/admin_outing_state_screen.dart
@@ -122,11 +122,15 @@ class _AdminOutingStateScreen extends ConsumerState<AdminOutingStateScreen> {
                       ref.read(studentCouncilMemberFilterProvider),
                     ),
                     onReset: () {
-                      ref.read(studentCouncilMembersProvider.notifier).clearFilter();
+                      ref
+                          .read(studentCouncilMembersProvider.notifier)
+                          .clearFilter();
                       ref.read(studentCouncilMembersProvider.notifier).reload();
                     },
                     onApply: (selection) {
-                      ref.read(studentCouncilMembersProvider.notifier).updateFilter(
+                      ref
+                          .read(studentCouncilMembersProvider.notifier)
+                          .updateFilter(
                             StudentCouncilFilterRequest(
                               grade: selection.grade,
                               gender: selection.gender,
@@ -143,73 +147,106 @@ class _AdminOutingStateScreen extends ConsumerState<AdminOutingStateScreen> {
             ),
             AppGap.v12,
             Expanded(
-              child: membersAsync.when(
-                data: (members) {
-                  final filteredMembers = searchText.trim().isEmpty
-                      ? members
-                      : members
-                          .where(
-                            (member) => member.name
-                                .toLowerCase()
-                                .contains(searchText.toLowerCase()),
-                          )
-                          .toList();
-
-                  if (filteredMembers.isEmpty) {
-                    return Center(
-                      child: Text(
-                        searchText.trim().isEmpty
-                            ? '조회된 학생이 없어요.'
-                            : '검색 결과가 없어요.',
-                        style: AppTextStyles.text2.copyWith(
-                          color: context.sub2Color,
-                        ),
-                      ),
-                    );
-                  }
-
-                  return ListView.separated(
-                    itemCount: filteredMembers.length,
-                    itemBuilder: (context, index) {
-                      final member = filteredMembers[index];
-                      return AdminOutingStateContainer(
-                        memberId: member.memberId,
-                        name: member.name,
-                        grade: member.grade,
-                        major: member.department,
-                        studentRole: member.studentRole,
-                      );
-                    },
-                    separatorBuilder: (context, index) {
-                      return Divider(
-                        thickness: 1,
-                        color: context.buttonColor,
-                      );
-                    },
-                  );
+              child: RefreshIndicator(
+                onRefresh: () {
+                  return ref
+                      .read(studentCouncilMembersProvider.notifier)
+                      .reload();
                 },
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, _) => Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        error is StudentCouncilMembersException
-                            ? error.message
-                            : '학생 목록을 불러오지 못했어요.',
-                        style: AppTextStyles.text2.copyWith(
-                          color: context.sub2Color,
-                        ),
-                        textAlign: TextAlign.center,
+                child: membersAsync.when(
+                  data: (members) {
+                    final filteredMembers = searchText.trim().isEmpty
+                        ? members
+                        : members
+                            .where(
+                              (member) => member.name
+                                  .toLowerCase()
+                                  .contains(searchText.toLowerCase()),
+                            )
+                            .toList();
+
+                    if (filteredMembers.isEmpty) {
+                      return ListView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        children: [
+                          SizedBox(
+                            height: 280,
+                            child: Center(
+                              child: Text(
+                                searchText.trim().isEmpty
+                                    ? '조회된 학생이 없어요.'
+                                    : '검색 결과가 없어요.',
+                                style: AppTextStyles.text2.copyWith(
+                                  color: context.sub2Color,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      );
+                    }
+
+                    return ListView.separated(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      itemCount: filteredMembers.length,
+                      itemBuilder: (context, index) {
+                        final member = filteredMembers[index];
+                        return AdminOutingStateContainer(
+                          memberId: member.memberId,
+                          name: member.name,
+                          grade: member.grade,
+                          major: member.department,
+                          studentRole: member.studentRole,
+                        );
+                      },
+                      separatorBuilder: (context, index) {
+                        return Divider(
+                          thickness: 1,
+                          color: context.buttonColor,
+                        );
+                      },
+                    );
+                  },
+                  loading: () => ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    children: const [
+                      SizedBox(
+                        height: 280,
+                        child: Center(child: CircularProgressIndicator()),
                       ),
-                      AppGap.v12,
-                      TextButton(
-                        onPressed: () {
-                          ref
-                              .read(studentCouncilMembersProvider.notifier)
-                              .reload();
-                        },
-                        child: const Text('다시 시도'),
+                    ],
+                  ),
+                  error: (error, _) => ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    children: [
+                      SizedBox(
+                        height: 280,
+                        child: Center(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                error is StudentCouncilMembersException
+                                    ? error.message
+                                    : '학생 목록을 불러오지 못했어요.',
+                                style: AppTextStyles.text2.copyWith(
+                                  color: context.sub2Color,
+                                ),
+                                textAlign: TextAlign.center,
+                              ),
+                              AppGap.v12,
+                              TextButton(
+                                onPressed: () {
+                                  ref
+                                      .read(studentCouncilMembersProvider
+                                          .notifier)
+                                      .reload();
+                                },
+                                child: const Text('다시 시도'),
+                              ),
+                            ],
+                          ),
+                        ),
                       ),
                     ],
                   ),
@@ -223,7 +260,8 @@ class _AdminOutingStateScreen extends ConsumerState<AdminOutingStateScreen> {
     );
   }
 
-  FilterSheetSelection _selectionFromFilter(StudentCouncilFilterRequest filter) {
+  FilterSheetSelection _selectionFromFilter(
+      StudentCouncilFilterRequest filter) {
     return FilterSheetSelection(
       grade: filter.grade,
       gender: filter.gender,

--- a/lib/features/outing/presentation/screens/outing_state_screen.dart
+++ b/lib/features/outing/presentation/screens/outing_state_screen.dart
@@ -119,66 +119,99 @@ class _OutingStateScreenState extends ConsumerState<OutingStateScreen> {
             ),
             AppGap.v12,
             Expanded(
-              child: outingStudents.when(
-                data: (students) {
-                  final filteredList = _filterStudents(students, searchText);
-
-                  if (filteredList.isEmpty) {
-                    return Center(
-                      child: Text(
-                        searchText.isEmpty
-                            ? '현재 외출 중인 학생이 없어요.'
-                            : '검색 결과가 없어요.',
-                        style: AppTextStyles.text2.copyWith(
-                          color: context.sub2Color,
-                        ),
-                      ),
-                    );
-                  }
-
-                  return ListView.separated(
-                    itemCount: filteredList.length,
-                    itemBuilder: (context, index) {
-                      final member = filteredList[index];
-                      return SearchProfileList(
-                        memberId: member.memberId,
-                        name: member.name,
-                        grade: member.grade,
-                        major: member.department,
-                        role: role,
-                        outingAt: member.outingAt,
-                      );
-                    },
-                    separatorBuilder: (context, index) {
-                      return Divider(
-                        thickness: 1,
-                        color: context.buttonColor,
-                      );
-                    },
-                  );
+              child: RefreshIndicator(
+                onRefresh: () {
+                  return ref
+                      .read(currentOutingStudentsProvider.notifier)
+                      .reload();
                 },
-                loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, _) => Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        error is CurrentOutingStudentsException
-                            ? error.message
-                            : '외출 목록을 불러오지 못했어요.',
-                        style: AppTextStyles.text2.copyWith(
-                          color: context.sub2Color,
-                        ),
-                        textAlign: TextAlign.center,
+                child: outingStudents.when(
+                  data: (students) {
+                    final filteredList = _filterStudents(students, searchText);
+
+                    if (filteredList.isEmpty) {
+                      return ListView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        children: [
+                          SizedBox(
+                            height: 280,
+                            child: Center(
+                              child: Text(
+                                searchText.isEmpty
+                                    ? '현재 외출 중인 학생이 없어요.'
+                                    : '검색 결과가 없어요.',
+                                style: AppTextStyles.text2.copyWith(
+                                  color: context.sub2Color,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      );
+                    }
+
+                    return ListView.separated(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      itemCount: filteredList.length,
+                      itemBuilder: (context, index) {
+                        final member = filteredList[index];
+                        return SearchProfileList(
+                          memberId: member.memberId,
+                          name: member.name,
+                          grade: member.grade,
+                          major: member.department,
+                          role: role,
+                          outingAt: member.outingAt,
+                        );
+                      },
+                      separatorBuilder: (context, index) {
+                        return Divider(
+                          thickness: 1,
+                          color: context.buttonColor,
+                        );
+                      },
+                    );
+                  },
+                  loading: () => ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    children: const [
+                      SizedBox(
+                        height: 280,
+                        child: Center(child: CircularProgressIndicator()),
                       ),
-                      AppGap.v12,
-                      TextButton(
-                        onPressed: () {
-                          ref
-                              .read(currentOutingStudentsProvider.notifier)
-                              .reload();
-                        },
-                        child: const Text('다시 시도'),
+                    ],
+                  ),
+                  error: (error, _) => ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    children: [
+                      SizedBox(
+                        height: 280,
+                        child: Center(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                error is CurrentOutingStudentsException
+                                    ? error.message
+                                    : '외출 목록을 불러오지 못했어요.',
+                                style: AppTextStyles.text2.copyWith(
+                                  color: context.sub2Color,
+                                ),
+                                textAlign: TextAlign.center,
+                              ),
+                              AppGap.v12,
+                              TextButton(
+                                onPressed: () {
+                                  ref
+                                      .read(currentOutingStudentsProvider
+                                          .notifier)
+                                      .reload();
+                                },
+                                child: const Text('다시 시도'),
+                              ),
+                            ],
+                          ),
+                        ),
                       ),
                     ],
                   ),

--- a/lib/features/outing/presentation/screens/outing_waiting_screen.dart
+++ b/lib/features/outing/presentation/screens/outing_waiting_screen.dart
@@ -31,6 +31,13 @@ class OutingWaitingScreen extends ConsumerStatefulWidget {
 }
 
 class _OutingWaitingScreenState extends ConsumerState<OutingWaitingScreen> {
+  Future<void> _onRefresh() async {
+    await Future.wait([
+      ref.read(currentOutingStudentsProvider.notifier).reload(),
+      ref.read(lateRankStudentsProvider.notifier).reload(),
+    ]);
+  }
+
   @override
   Widget build(BuildContext context) {
     final role = ref.watch(roleProvider);
@@ -44,81 +51,85 @@ class _OutingWaitingScreenState extends ConsumerState<OutingWaitingScreen> {
     return BaseScaffold(
       showAppBar: true,
       showAppBarLogo: true,
-      body: CustomScrollView(
-        slivers: [
-          SliverToBoxAdapter(
-            child: Column(
-              children: [
-                const Padding(
-                  padding: EdgeInsets.only(bottom: 24),
-                  child: MyOutingStatusCard(),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(
-                    bottom: 24,
+      body: RefreshIndicator(
+        onRefresh: _onRefresh,
+        child: CustomScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          slivers: [
+            SliverToBoxAdapter(
+              child: Column(
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(bottom: 24),
+                    child: MyOutingStatusCard(),
                   ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
+                  Padding(
+                    padding: const EdgeInsets.only(
+                      bottom: 24,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              '지각자 TOP 3',
+                              style: AppTextStyles.title3.copyWith(
+                                color: context.mainTextColor,
+                              ),
+                            ),
+                            role == RoleEnum.admin
+                                ? const ViewMoreUsers(
+                                    path: RoutePath.studentCouncilLate,
+                                  )
+                                : const SizedBox(),
+                          ],
+                        ),
+                        AppGap.v12,
+                        _buildLateRankSection(lateRankStudents),
+                        AppGap.v12,
+                      ],
+                    ),
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        crossAxisAlignment: CrossAxisAlignment.center,
                         children: [
                           Text(
-                            '지각자 TOP 3',
+                            '외출 현황',
                             style: AppTextStyles.title3.copyWith(
                               color: context.mainTextColor,
                             ),
                           ),
-                          role == RoleEnum.admin
-                              ? const ViewMoreUsers(
-                                  path: RoutePath.studentCouncilLate,
-                                )
-                              : const SizedBox(),
+                          AppGap.h8,
+                          Text(
+                            '$approvedStudentCount',
+                            style: AppTextStyles.caption1
+                                .copyWith(color: AppColors.mainColor),
+                          ),
+                          Text(
+                            "명이 외출중",
+                            style: AppTextStyles.caption1.copyWith(
+                              color: context.isDarkMode
+                                  ? AppColors.sub1Dark
+                                  : AppColors.sub2,
+                            ),
+                          ),
                         ],
                       ),
-                      AppGap.v12,
-                      _buildLateRankSection(lateRankStudents),
-                      AppGap.v12,
+                      const ViewMoreUsers(),
                     ],
                   ),
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Text(
-                          '외출 현황',
-                          style: AppTextStyles.title3.copyWith(
-                            color: context.mainTextColor,
-                          ),
-                        ),
-                        AppGap.h8,
-                        Text(
-                          '$approvedStudentCount',
-                          style: AppTextStyles.caption1
-                              .copyWith(color: AppColors.mainColor),
-                        ),
-                        Text(
-                          "명이 외출중",
-                          style: AppTextStyles.caption1.copyWith(
-                            color: context.isDarkMode
-                                ? AppColors.sub1Dark
-                                : AppColors.sub2,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const ViewMoreUsers(),
-                  ],
-                ),
-                AppGap.v12,
-              ],
+                  AppGap.v12,
+                ],
+              ),
             ),
-          ),
-          ..._buildOutingStudentSlivers(currentOutingStudents),
-        ],
+            ..._buildOutingStudentSlivers(currentOutingStudents),
+          ],
+        ),
       ),
       floatingActionButton: Column(
         mainAxisSize: MainAxisSize.min,

--- a/lib/features/report/presentation/screens/admin_report_list_screen.dart
+++ b/lib/features/report/presentation/screens/admin_report_list_screen.dart
@@ -72,10 +72,18 @@ class _AdminReportListScreenState extends ConsumerState<AdminReportListScreen> {
           ),
           AppGap.v24,
           Expanded(
-            child: _ReportListBody(
-              pendingReportsAsync: pendingReportsAsync,
-              resolvedReportsAsync: resolvedReportsAsync,
-              query: _query,
+            child: RefreshIndicator(
+              onRefresh: () async {
+                await Future.wait([
+                  ref.read(pendingReportsProvider.notifier).reload(),
+                  ref.read(resolvedReportsProvider.notifier).reload(),
+                ]);
+              },
+              child: _ReportListBody(
+                pendingReportsAsync: pendingReportsAsync,
+                resolvedReportsAsync: resolvedReportsAsync,
+                query: _query,
+              ),
             ),
           ),
         ],
@@ -111,7 +119,15 @@ class _ReportListBody extends ConsumerWidget {
         : null;
 
     if (isLoading) {
-      return const Center(child: CircularProgressIndicator());
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: const [
+          SizedBox(
+            height: 280,
+            child: Center(child: CircularProgressIndicator()),
+          ),
+        ],
+      );
     }
 
     if (error != null) {
@@ -149,15 +165,24 @@ class _ReportListBody extends ConsumerWidget {
           }).toList(growable: false);
 
     if (filteredReports.isEmpty) {
-      return Center(
-        child: Text(
-          normalizedQuery.isEmpty ? '신고 내역이 없어요.' : '검색 결과가 없어요.',
-          style: AppTextStyles.text2.copyWith(color: context.sub2Color),
-        ),
+      return ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          SizedBox(
+            height: 280,
+            child: Center(
+              child: Text(
+                normalizedQuery.isEmpty ? '신고 내역이 없어요.' : '검색 결과가 없어요.',
+                style: AppTextStyles.text2.copyWith(color: context.sub2Color),
+              ),
+            ),
+          ),
+        ],
       );
     }
 
     return ListView.separated(
+      physics: const AlwaysScrollableScrollPhysics(),
       itemCount: filteredReports.length,
       separatorBuilder: (_, __) => Divider(
         color: context.buttonColor,
@@ -315,19 +340,27 @@ class _ReportErrorView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            message,
-            style: AppTextStyles.text2.copyWith(color: context.sub2Color),
-            textAlign: TextAlign.center,
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: [
+        SizedBox(
+          height: 280,
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  message,
+                  style: AppTextStyles.text2.copyWith(color: context.sub2Color),
+                  textAlign: TextAlign.center,
+                ),
+                AppGap.v12,
+                TextButton(onPressed: onRetry, child: const Text('다시 시도')),
+              ],
+            ),
           ),
-          AppGap.v12,
-          TextButton(onPressed: onRetry, child: const Text('다시 시도')),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## 💡 개요
여러 화면에서 새로 고침 동작을 일관되게 정리하고, 관리자 사용성 향상을 위한 상단 액션을 추가했습니다.

## 🔗 관련 이슈
Closes #78

## 📃 작업내용
- 여러 화면에서 새로 고침 트리거 및 UI 반응을 공통 흐름에 맞게 정리했습니다.
- QR 스캔 후 반응 화면에서 뒤로가기 동작을 홈 이동 흐름으로 개선했습니다.
- 버튼 콜백 처리 주석을 실제 동작 기준으로 정리해 오해 가능성을 줄였습니다.
- 관리자 권한일 때 앱바에 학생회 보고서 화면 이동 아이콘 버튼을 추가했습니다.

## 🔍 테스트 방법
- flutter analyze 실행
- 결과: trailing comma 관련 info 3건 확인
  - lib/features/outing/presentation/screens/admin_outing_state_screen.dart:242
  - lib/features/outing/presentation/screens/admin_outing_state_screen.dart:264
  - lib/features/outing/presentation/screens/outing_state_screen.dart:207

## 🖼️ 스크린샷
필요 시 리뷰 코멘트에 추가하겠습니다.

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.
