### PR TITLE
🔀 :: (#87) - setState 사용 화면을 Riverpod으로 전환

### DIFF
--- a/lib/core/widgets/chips/category_chip.dart
+++ b/lib/core/widgets/chips/category_chip.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/theme_context.dart';
 import 'package:goms/core/theme/typography/app_text_styles.dart';
 
-class CategoryChip extends StatefulWidget {
+final _categoryChipSelectionProvider =
+    StateProvider.autoDispose.family<bool, Object>((ref, key) => false);
+
+class CategoryChip extends ConsumerStatefulWidget {
   final String category;
   final bool? selected;
   final ValueChanged<bool>? onChanged;
@@ -16,16 +21,24 @@ class CategoryChip extends StatefulWidget {
   });
 
   @override
-  State<CategoryChip> createState() => _CategoryChipState();
+  ConsumerState<CategoryChip> createState() => _CategoryChipState();
 }
 
-class _CategoryChipState extends State<CategoryChip> {
-  bool isSelected = false;
+class _CategoryChipState extends ConsumerState<CategoryChip> {
+  late final Object _providerKey;
+
+  @override
+  void initState() {
+    super.initState();
+    _providerKey = Object();
+  }
 
   @override
   Widget build(BuildContext context) {
     final isControlled = widget.selected != null;
-    final selected = isControlled ? widget.selected! : isSelected;
+    final selected = isControlled
+        ? widget.selected!
+        : ref.watch(_categoryChipSelectionProvider(_providerKey));
 
     return GestureDetector(
       onTap: () {
@@ -34,7 +47,8 @@ class _CategoryChipState extends State<CategoryChip> {
           widget.onChanged?.call(next);
           return;
         }
-        setState(() => isSelected = next);
+        ref.read(_categoryChipSelectionProvider(_providerKey).notifier).state =
+            next;
         widget.onChanged?.call(next);
       },
       child: Container(

--- a/lib/core/widgets/chips/category_chip.dart
+++ b/lib/core/widgets/chips/category_chip.dart
@@ -1,12 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/theme_context.dart';
 import 'package:goms/core/theme/typography/app_text_styles.dart';
 
 final _categoryChipSelectionProvider =
-    StateProvider.autoDispose.family<bool, Object>((ref, key) => false);
+    NotifierProvider.autoDispose.family<
+      _CategoryChipSelectionNotifier,
+      bool,
+      Object
+    >(_CategoryChipSelectionNotifier.new);
+
+class _CategoryChipSelectionNotifier extends Notifier<bool> {
+  _CategoryChipSelectionNotifier(this.key);
+
+  final Object key;
+
+  @override
+  bool build() => false;
+
+  void setSelected(bool value) => state = value;
+}
 
 class CategoryChip extends ConsumerStatefulWidget {
   final String category;
@@ -47,8 +61,9 @@ class _CategoryChipState extends ConsumerState<CategoryChip> {
           widget.onChanged?.call(next);
           return;
         }
-        ref.read(_categoryChipSelectionProvider(_providerKey).notifier).state =
-            next;
+        ref
+            .read(_categoryChipSelectionProvider(_providerKey).notifier)
+            .setSelected(next);
         widget.onChanged?.call(next);
       },
       child: Container(

--- a/lib/features/auth/login/presentation/screens/login_screen.dart
+++ b/lib/features/auth/login/presentation/screens/login_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:go_router/go_router.dart';
 import 'package:goms/core/router/route_path.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
@@ -14,7 +13,20 @@ import 'package:goms/core/widgets/text_fields/email_text_field.dart';
 import 'package:goms/core/widgets/text_fields/password_text_field.dart';
 
 final _loginButtonEnabledProvider =
-    StateProvider.autoDispose.family<bool, Object>((ref, key) => false);
+    NotifierProvider.autoDispose.family<_LoginButtonEnabledNotifier, bool, Object>(
+      _LoginButtonEnabledNotifier.new,
+    );
+
+class _LoginButtonEnabledNotifier extends Notifier<bool> {
+  _LoginButtonEnabledNotifier(this.key);
+
+  final Object key;
+
+  @override
+  bool build() => false;
+
+  void setEnabled(bool value) => state = value;
+}
 
 class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
@@ -30,8 +42,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   late final Object _providerKey;
 
   void _onTextChanged() {
-    ref.read(_loginButtonEnabledProvider(_providerKey).notifier).state =
-        _emailController.text.isNotEmpty && _passwordController.text.isNotEmpty;
+    ref.read(_loginButtonEnabledProvider(_providerKey).notifier).setEnabled(
+          _emailController.text.isNotEmpty &&
+              _passwordController.text.isNotEmpty,
+        );
   }
 
   @override

--- a/lib/features/auth/login/presentation/screens/login_screen.dart
+++ b/lib/features/auth/login/presentation/screens/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:go_router/go_router.dart';
 import 'package:goms/core/router/route_path.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
@@ -12,6 +13,9 @@ import 'package:goms/features/auth/login/presentation/providers/login_provider.d
 import 'package:goms/core/widgets/text_fields/email_text_field.dart';
 import 'package:goms/core/widgets/text_fields/password_text_field.dart';
 
+final _loginButtonEnabledProvider =
+    StateProvider.autoDispose.family<bool, Object>((ref, key) => false);
+
 class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
 
@@ -23,17 +27,20 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   late final ProviderSubscription<LoginState> _loginSubscription;
+  late final Object _providerKey;
 
   void _onTextChanged() {
-    if (!mounted) return;
-    setState(() {});
+    ref.read(_loginButtonEnabledProvider(_providerKey).notifier).state =
+        _emailController.text.isNotEmpty && _passwordController.text.isNotEmpty;
   }
 
   @override
   void initState() {
     super.initState();
+    _providerKey = Object();
     _emailController.addListener(_onTextChanged);
     _passwordController.addListener(_onTextChanged);
+    _onTextChanged();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(loginProvider.notifier).reset();
     });
@@ -77,9 +84,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     super.dispose();
   }
 
-  bool get _isButtonEnabled =>
-      _emailController.text.isNotEmpty && _passwordController.text.isNotEmpty;
-
   void _handleLogin() {
     ref
         .read(loginProvider.notifier)
@@ -94,11 +98,12 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   Widget build(BuildContext context) {
     final loginState = ref.watch(loginProvider);
     final isLoading = loginState.status == LoginStatus.loading;
+    final isButtonEnabled = ref.watch(_loginButtonEnabledProvider(_providerKey));
 
     return AuthBaseScreen(
       title: '로그인',
       confirmText: '로그인',
-      isConfirmEnabled: _isButtonEnabled,
+      isConfirmEnabled: isButtonEnabled,
       isLoading: isLoading,
       onConfirm: _handleLogin,
       children: [

--- a/lib/features/home/shared/presentation/widgets/view_more_users.dart
+++ b/lib/features/home/shared/presentation/widgets/view_more_users.dart
@@ -14,14 +14,15 @@ class ViewMoreUsers extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: 51,
-      height: 24,
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: 24),
       child: ElevatedButton(
         onPressed: () {
           context.push(path);
         },
         style: ElevatedButton.styleFrom(
+          minimumSize: const Size(0, 24),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           backgroundColor: context.surfaceColor,
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           shape: RoundedRectangleBorder(

--- a/lib/features/map/shared/presentation/providers/kakao_map_background_provider.dart
+++ b/lib/features/map/shared/presentation/providers/kakao_map_background_provider.dart
@@ -1,10 +1,39 @@
-import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kakao_map_sdk/kakao_map_sdk.dart' as kakao;
 
 final kakaoMapBackgroundErrorProvider =
-    StateProvider.autoDispose.family<String?, String>((ref, mapId) => null);
+    NotifierProvider.autoDispose.family<
+      _KakaoMapBackgroundErrorNotifier,
+      String?,
+      String
+    >(_KakaoMapBackgroundErrorNotifier.new);
 
 final kakaoMapBackgroundControllerProvider =
-    StateProvider.autoDispose.family<kakao.KakaoMapController?, String>(
-      (ref, mapId) => null,
-    );
+    NotifierProvider.autoDispose.family<
+      _KakaoMapBackgroundControllerNotifier,
+      kakao.KakaoMapController?,
+      String
+    >(_KakaoMapBackgroundControllerNotifier.new);
+
+class _KakaoMapBackgroundErrorNotifier extends Notifier<String?> {
+  _KakaoMapBackgroundErrorNotifier(this.mapId);
+
+  final String mapId;
+
+  @override
+  String? build() => null;
+
+  void setMessage(String? value) => state = value;
+}
+
+class _KakaoMapBackgroundControllerNotifier
+    extends Notifier<kakao.KakaoMapController?> {
+  _KakaoMapBackgroundControllerNotifier(this.mapId);
+
+  final String mapId;
+
+  @override
+  kakao.KakaoMapController? build() => null;
+
+  void setController(kakao.KakaoMapController? value) => state = value;
+}

--- a/lib/features/map/shared/presentation/providers/kakao_map_background_provider.dart
+++ b/lib/features/map/shared/presentation/providers/kakao_map_background_provider.dart
@@ -1,4 +1,10 @@
 import 'package:flutter_riverpod/legacy.dart';
+import 'package:kakao_map_sdk/kakao_map_sdk.dart' as kakao;
 
 final kakaoMapBackgroundErrorProvider =
     StateProvider.autoDispose.family<String?, String>((ref, mapId) => null);
+
+final kakaoMapBackgroundControllerProvider =
+    StateProvider.autoDispose.family<kakao.KakaoMapController?, String>(
+      (ref, mapId) => null,
+    );

--- a/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
+++ b/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
@@ -37,6 +37,13 @@ class _KakaoMapBackgroundState extends ConsumerState<KakaoMapBackground> {
   @override
   void didUpdateWidget(covariant KakaoMapBackground oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.focusPlace?.name != widget.focusPlace?.name ||
+        oldWidget.focusPlace?.address != widget.focusPlace?.address ||
+        oldWidget.places.length != widget.places.length ||
+        oldWidget.routePath.length != widget.routePath.length) {
+      ref.read(kakaoMapBackgroundControllerProvider(_mapId).notifier).state =
+          _controller;
+    }
     if (KakaoMapRuntime.instance.isMapAvailable) {
       _renderMapObjects();
     }
@@ -175,6 +182,7 @@ class _KakaoMapBackgroundState extends ConsumerState<KakaoMapBackground> {
   @override
   Widget build(BuildContext context) {
     final errorMessage = ref.watch(kakaoMapBackgroundErrorProvider(_mapId));
+    final controller = ref.watch(kakaoMapBackgroundControllerProvider(_mapId));
     final unavailableReason = KakaoMapRuntime.instance.unavailableReason;
     if (!KakaoMapRuntime.instance.isMapAvailable) {
       return Center(
@@ -209,9 +217,10 @@ class _KakaoMapBackgroundState extends ConsumerState<KakaoMapBackground> {
               if (!mounted) {
                 return;
               }
-              setState(() {
-                _controller = controller;
-              });
+              _controller = controller;
+              ref
+                  .read(kakaoMapBackgroundControllerProvider(_mapId).notifier)
+                  .state = controller;
               debugPrint('KakaoMapBackground onMapReady');
               _renderMapObjects();
             },
@@ -221,7 +230,7 @@ class _KakaoMapBackgroundState extends ConsumerState<KakaoMapBackground> {
             },
           ),
         ),
-        if (_controller == null && errorMessage == null)
+        if (controller == null && errorMessage == null)
           const Positioned.fill(
             child: Center(
               child: CircularProgressIndicator(),

--- a/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
+++ b/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
@@ -41,8 +41,9 @@ class _KakaoMapBackgroundState extends ConsumerState<KakaoMapBackground> {
         oldWidget.focusPlace?.address != widget.focusPlace?.address ||
         oldWidget.places.length != widget.places.length ||
         oldWidget.routePath.length != widget.routePath.length) {
-      ref.read(kakaoMapBackgroundControllerProvider(_mapId).notifier).state =
-          _controller;
+      ref
+          .read(kakaoMapBackgroundControllerProvider(_mapId).notifier)
+          .setController(_controller);
     }
     if (KakaoMapRuntime.instance.isMapAvailable) {
       _renderMapObjects();
@@ -158,14 +159,16 @@ class _KakaoMapBackgroundState extends ConsumerState<KakaoMapBackground> {
   }
 
   void _setError(String message) {
-    ref.read(kakaoMapBackgroundErrorProvider(_mapId).notifier).state = message;
+    ref.read(kakaoMapBackgroundErrorProvider(_mapId).notifier).setMessage(
+          message,
+        );
   }
 
   void _clearError() {
     if (ref.read(kakaoMapBackgroundErrorProvider(_mapId)) == null) {
       return;
     }
-    ref.read(kakaoMapBackgroundErrorProvider(_mapId).notifier).state = null;
+    ref.read(kakaoMapBackgroundErrorProvider(_mapId).notifier).setMessage(null);
   }
 
   String _buildErrorMessage(Object error) {
@@ -220,7 +223,7 @@ class _KakaoMapBackgroundState extends ConsumerState<KakaoMapBackground> {
               _controller = controller;
               ref
                   .read(kakaoMapBackgroundControllerProvider(_mapId).notifier)
-                  .state = controller;
+                  .setController(controller);
               debugPrint('KakaoMapBackground onMapReady');
               _renderMapObjects();
             },

--- a/lib/features/member/presentation/widgets/member_filter_bottom_sheet.dart
+++ b/lib/features/member/presentation/widgets/member_filter_bottom_sheet.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
@@ -46,9 +45,22 @@ class MemberFilterSheetSelection {
 }
 
 final _memberFilterSelectionProvider =
-    StateProvider.autoDispose.family<MemberFilterSheetSelection, (Object, MemberFilterSheetSelection)>(
-      (ref, args) => args.$2,
-    );
+    NotifierProvider.autoDispose.family<
+      _MemberFilterSelectionNotifier,
+      MemberFilterSheetSelection,
+      (Object, MemberFilterSheetSelection)
+    >(_MemberFilterSelectionNotifier.new);
+
+class _MemberFilterSelectionNotifier extends Notifier<MemberFilterSheetSelection> {
+  _MemberFilterSelectionNotifier(this.args);
+
+  final (Object, MemberFilterSheetSelection) args;
+
+  @override
+  MemberFilterSheetSelection build() => args.$2;
+
+  void setSelection(MemberFilterSheetSelection selection) => state = selection;
+}
 
 class MemberFilterBottomSheet extends ConsumerStatefulWidget {
   const MemberFilterBottomSheet({
@@ -313,15 +325,17 @@ class _MemberFilterBottomSheetState extends ConsumerState<MemberFilterBottomShee
   }
 
   void _handleReset() {
-    ref.read(_memberFilterSelectionProvider(_providerKey).notifier).state =
-        const MemberFilterSheetSelection();
+    ref
+        .read(_memberFilterSelectionProvider(_providerKey).notifier)
+        .setSelection(const MemberFilterSheetSelection());
     widget.onReset?.call();
     Navigator.pop(context);
   }
 
   void _updateSelection(MemberFilterSheetSelection selection) {
-    ref.read(_memberFilterSelectionProvider(_providerKey).notifier).state =
-        selection;
+    ref
+        .read(_memberFilterSelectionProvider(_providerKey).notifier)
+        .setSelection(selection);
     _notifySelectionChanged(selection);
   }
 

--- a/lib/features/member/presentation/widgets/member_filter_bottom_sheet.dart
+++ b/lib/features/member/presentation/widgets/member_filter_bottom_sheet.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
@@ -20,9 +22,35 @@ class MemberFilterSheetSelection {
   final String? department;
   final String? status;
   final String? role;
+
+  MemberFilterSheetSelection copyWith({
+    int? grade,
+    String? gender,
+    String? department,
+    String? status,
+    String? role,
+    bool clearGrade = false,
+    bool clearGender = false,
+    bool clearDepartment = false,
+    bool clearStatus = false,
+    bool clearRole = false,
+  }) {
+    return MemberFilterSheetSelection(
+      grade: clearGrade ? null : (grade ?? this.grade),
+      gender: clearGender ? null : (gender ?? this.gender),
+      department: clearDepartment ? null : (department ?? this.department),
+      status: clearStatus ? null : (status ?? this.status),
+      role: clearRole ? null : (role ?? this.role),
+    );
+  }
 }
 
-class MemberFilterBottomSheet extends StatefulWidget {
+final _memberFilterSelectionProvider =
+    StateProvider.autoDispose.family<MemberFilterSheetSelection, (Object, MemberFilterSheetSelection)>(
+      (ref, args) => args.$2,
+    );
+
+class MemberFilterBottomSheet extends ConsumerStatefulWidget {
   const MemberFilterBottomSheet({
     super.key,
     this.initialSelection = const MemberFilterSheetSelection(),
@@ -35,29 +63,26 @@ class MemberFilterBottomSheet extends StatefulWidget {
   final VoidCallback? onReset;
 
   @override
-  State<MemberFilterBottomSheet> createState() =>
+  ConsumerState<MemberFilterBottomSheet> createState() =>
       _MemberFilterBottomSheetState();
 }
 
-class _MemberFilterBottomSheetState extends State<MemberFilterBottomSheet> {
-  int? _grade;
-  String? _gender;
-  String? _department;
-  String? _status;
-  String? _role;
+class _MemberFilterBottomSheetState extends ConsumerState<MemberFilterBottomSheet> {
+  late final Object _providerIdentity;
+
+  (Object, MemberFilterSheetSelection) get _providerKey =>
+      (_providerIdentity, widget.initialSelection);
 
   @override
   void initState() {
     super.initState();
-    _grade = widget.initialSelection.grade;
-    _gender = widget.initialSelection.gender;
-    _department = widget.initialSelection.department;
-    _status = widget.initialSelection.status;
-    _role = widget.initialSelection.role;
+    _providerIdentity = Object();
   }
 
   @override
   Widget build(BuildContext context) {
+    final selection = ref.watch(_memberFilterSelectionProvider(_providerKey));
+
     return CommonBottomSheet(
       title: '필터',
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
@@ -78,19 +103,18 @@ class _MemberFilterBottomSheetState extends State<MemberFilterBottomSheet> {
                 child: CategoryChip(
                   category: '학생',
                   selected:
-                      _role == 'ROLE_STUDENT' && _status != 'CANNOT_OUTING',
+                      selection.role == 'ROLE_STUDENT' &&
+                      selection.status != 'CANNOT_OUTING',
                   onChanged: (selected) {
-                    setState(() {
-                      if (!selected) {
-                        _role = null;
-                      } else {
-                        _role = 'ROLE_STUDENT';
-                        if (_status == 'CANNOT_OUTING') {
-                          _status = null;
-                        }
-                      }
-                    });
-                    _notifySelectionChanged();
+                    _updateSelection(
+                      !selected
+                          ? selection.copyWith(clearRole: true)
+                          : selection.copyWith(
+                              role: 'ROLE_STUDENT',
+                              clearStatus:
+                                  selection.status == 'CANNOT_OUTING',
+                            ),
+                    );
                   },
                 ),
               ),
@@ -98,32 +122,30 @@ class _MemberFilterBottomSheetState extends State<MemberFilterBottomSheet> {
               Expanded(
                 child: CategoryChip(
                   category: '학생회',
-                  selected: _role == 'ROLE_STUDENT_COUNCIL',
-                  onChanged: (selected) {
-                    setState(() {
-                      _role = selected ? 'ROLE_STUDENT_COUNCIL' : null;
-                      if (selected && _status == 'CANNOT_OUTING') {
-                        _status = null;
-                      }
-                    });
-                    _notifySelectionChanged();
-                  },
+                  selected: selection.role == 'ROLE_STUDENT_COUNCIL',
+                  onChanged: (selected) => _updateSelection(
+                    selected
+                        ? selection.copyWith(
+                            role: 'ROLE_STUDENT_COUNCIL',
+                            clearStatus: selection.status == 'CANNOT_OUTING',
+                          )
+                        : selection.copyWith(clearRole: true),
+                  ),
                 ),
               ),
               AppGap.h8,
               Expanded(
                 child: CategoryChip(
                   category: '외출 금지',
-                  selected: _status == 'CANNOT_OUTING',
-                  onChanged: (selected) {
-                    setState(() {
-                      _status = selected ? 'CANNOT_OUTING' : null;
-                      if (selected) {
-                        _role = 'ROLE_STUDENT';
-                      }
-                    });
-                    _notifySelectionChanged();
-                  },
+                  selected: selection.status == 'CANNOT_OUTING',
+                  onChanged: (selected) => _updateSelection(
+                    selected
+                        ? selection.copyWith(
+                            status: 'CANNOT_OUTING',
+                            role: 'ROLE_STUDENT',
+                          )
+                        : selection.copyWith(clearStatus: true),
+                  ),
                 ),
               ),
             ],
@@ -141,33 +163,39 @@ class _MemberFilterBottomSheetState extends State<MemberFilterBottomSheet> {
               Expanded(
                 child: CategoryChip(
                   category: '1학년',
-                  selected: _grade == 1,
-                  onChanged: (selected) => setState(() {
-                    _grade = selected ? 1 : null;
-                    _notifySelectionChanged();
-                  }),
+                  selected: selection.grade == 1,
+                  onChanged: (selected) => _updateSelection(
+                    selection.copyWith(
+                      grade: selected ? 1 : null,
+                      clearGrade: !selected,
+                    ),
+                  ),
                 ),
               ),
               AppGap.h8,
               Expanded(
                 child: CategoryChip(
                   category: '2학년',
-                  selected: _grade == 2,
-                  onChanged: (selected) => setState(() {
-                    _grade = selected ? 2 : null;
-                    _notifySelectionChanged();
-                  }),
+                  selected: selection.grade == 2,
+                  onChanged: (selected) => _updateSelection(
+                    selection.copyWith(
+                      grade: selected ? 2 : null,
+                      clearGrade: !selected,
+                    ),
+                  ),
                 ),
               ),
               AppGap.h8,
               Expanded(
                 child: CategoryChip(
                   category: '3학년',
-                  selected: _grade == 3,
-                  onChanged: (selected) => setState(() {
-                    _grade = selected ? 3 : null;
-                    _notifySelectionChanged();
-                  }),
+                  selected: selection.grade == 3,
+                  onChanged: (selected) => _updateSelection(
+                    selection.copyWith(
+                      grade: selected ? 3 : null,
+                      clearGrade: !selected,
+                    ),
+                  ),
                 ),
               ),
             ],
@@ -185,22 +213,26 @@ class _MemberFilterBottomSheetState extends State<MemberFilterBottomSheet> {
               Expanded(
                 child: CategoryChip(
                   category: '남성',
-                  selected: _gender == 'MALE',
-                  onChanged: (selected) => setState(() {
-                    _gender = selected ? 'MALE' : null;
-                    _notifySelectionChanged();
-                  }),
+                  selected: selection.gender == 'MALE',
+                  onChanged: (selected) => _updateSelection(
+                    selection.copyWith(
+                      gender: selected ? 'MALE' : null,
+                      clearGender: !selected,
+                    ),
+                  ),
                 ),
               ),
               AppGap.h8,
               Expanded(
                 child: CategoryChip(
                   category: '여성',
-                  selected: _gender == 'FEMALE',
-                  onChanged: (selected) => setState(() {
-                    _gender = selected ? 'FEMALE' : null;
-                    _notifySelectionChanged();
-                  }),
+                  selected: selection.gender == 'FEMALE',
+                  onChanged: (selected) => _updateSelection(
+                    selection.copyWith(
+                      gender: selected ? 'FEMALE' : null,
+                      clearGender: !selected,
+                    ),
+                  ),
                 ),
               ),
             ],
@@ -218,33 +250,39 @@ class _MemberFilterBottomSheetState extends State<MemberFilterBottomSheet> {
               Expanded(
                 child: CategoryChip(
                   category: 'sw',
-                  selected: _department == 'SW',
-                  onChanged: (selected) => setState(() {
-                    _department = selected ? 'SW' : null;
-                    _notifySelectionChanged();
-                  }),
+                  selected: selection.department == 'SW',
+                  onChanged: (selected) => _updateSelection(
+                    selection.copyWith(
+                      department: selected ? 'SW' : null,
+                      clearDepartment: !selected,
+                    ),
+                  ),
                 ),
               ),
               AppGap.h8,
               Expanded(
                 child: CategoryChip(
                   category: 'iot',
-                  selected: _department == 'IOT',
-                  onChanged: (selected) => setState(() {
-                    _department = selected ? 'IOT' : null;
-                    _notifySelectionChanged();
-                  }),
+                  selected: selection.department == 'IOT',
+                  onChanged: (selected) => _updateSelection(
+                    selection.copyWith(
+                      department: selected ? 'IOT' : null,
+                      clearDepartment: !selected,
+                    ),
+                  ),
                 ),
               ),
               AppGap.h8,
               Expanded(
                 child: CategoryChip(
                   category: 'ai',
-                  selected: _department == 'AI',
-                  onChanged: (selected) => setState(() {
-                    _department = selected ? 'AI' : null;
-                    _notifySelectionChanged();
-                  }),
+                  selected: selection.department == 'AI',
+                  onChanged: (selected) => _updateSelection(
+                    selection.copyWith(
+                      department: selected ? 'AI' : null,
+                      clearDepartment: !selected,
+                    ),
+                  ),
                 ),
               ),
             ],
@@ -275,26 +313,19 @@ class _MemberFilterBottomSheetState extends State<MemberFilterBottomSheet> {
   }
 
   void _handleReset() {
-    setState(() {
-      _grade = null;
-      _gender = null;
-      _department = null;
-      _status = null;
-      _role = null;
-    });
+    ref.read(_memberFilterSelectionProvider(_providerKey).notifier).state =
+        const MemberFilterSheetSelection();
     widget.onReset?.call();
     Navigator.pop(context);
   }
 
-  void _notifySelectionChanged() {
-    widget.onApply?.call(
-      MemberFilterSheetSelection(
-        grade: _grade,
-        gender: _gender,
-        department: _department,
-        status: _status,
-        role: _role,
-      ),
-    );
+  void _updateSelection(MemberFilterSheetSelection selection) {
+    ref.read(_memberFilterSelectionProvider(_providerKey).notifier).state =
+        selection;
+    _notifySelectionChanged(selection);
+  }
+
+  void _notifySelectionChanged(MemberFilterSheetSelection selection) {
+    widget.onApply?.call(selection);
   }
 }

--- a/lib/features/outing/presentation/widgets/admin_outing_state_container.dart
+++ b/lib/features/outing/presentation/widgets/admin_outing_state_container.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/icons/app_icons.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
@@ -8,6 +9,11 @@ import 'package:goms/core/theme/typography/app_text_styles.dart';
 import 'package:goms/core/widgets/avatars/profile_avatar.dart';
 import 'package:goms/features/home/domain/enums/student_role_enum.dart';
 import 'package:goms/features/outing/presentation/widgets/admin_bottom_sheet.dart';
+
+final _adminOutingStudentRoleProvider =
+    StateProvider.autoDispose.family<StudentRole, (Object, StudentRole)>(
+      (ref, args) => args.$2,
+    );
 
 class AdminOutingStateContainer extends ConsumerStatefulWidget {
   final int memberId;
@@ -34,24 +40,21 @@ class AdminOutingStateContainer extends ConsumerStatefulWidget {
 
 class _AdminOutingStateContainerState
     extends ConsumerState<AdminOutingStateContainer> {
-  late StudentRole _studentRole;
+  late final Object _providerIdentity;
+
+  (Object, StudentRole) get _providerKey =>
+      (_providerIdentity, widget.studentRole);
 
   @override
   void initState() {
     super.initState();
-    _studentRole = widget.studentRole;
-  }
-
-  @override
-  void didUpdateWidget(covariant AdminOutingStateContainer oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.studentRole != widget.studentRole) {
-      _studentRole = widget.studentRole;
-    }
+    _providerIdentity = Object();
   }
 
   @override
   Widget build(BuildContext context) {
+    final studentRole = ref.watch(_adminOutingStudentRoleProvider(_providerKey));
+
     return Container(
       color: context.backgroundColor,
       width: double.infinity,
@@ -64,17 +67,17 @@ class _AdminOutingStateContainerState
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 border: Border.all(
-                  color: _studentRole == StudentRole.council
+                  color: studentRole == StudentRole.council
                       ? AppColors.admin
-                      : _studentRole == StudentRole.outingBanned
+                      : studentRole == StudentRole.outingBanned
                           ? AppColors.negative
                           : Colors.transparent,
                   width: 4,
                 ),
               ),
               child: ProfileAvatar(
-                radius: _studentRole == StudentRole.outingBanned ||
-                        _studentRole == StudentRole.council
+                radius: studentRole == StudentRole.outingBanned ||
+                        studentRole == StudentRole.council
                     ? 22
                     : 24,
                 imageUrl: widget.profileImageUrl,
@@ -90,9 +93,9 @@ class _AdminOutingStateContainerState
               Text(
                 widget.name,
                 style: AppTextStyles.text1.copyWith(
-                  color: _studentRole == StudentRole.outingBanned
+                  color: studentRole == StudentRole.outingBanned
                       ? AppColors.negative
-                      : _studentRole == StudentRole.council
+                      : studentRole == StudentRole.council
                           ? AppColors.admin
                           : context.sub1Color,
                 ),
@@ -123,11 +126,15 @@ class _AdminOutingStateContainerState
                   backgroundColor: context.surfaceColor,
                   builder: (context) => AdminBottomSheet(
                     memberId: widget.memberId,
-                    studentRole: _studentRole,
+                    studentRole: studentRole,
                     onRoleChanged: (newRole) {
-                      setState(() {
-                        _studentRole = newRole;
-                      });
+                      ref
+                          .read(
+                            _adminOutingStudentRoleProvider(
+                              _providerKey,
+                            ).notifier,
+                          )
+                          .state = newRole;
                     },
                   ),
                 );

--- a/lib/features/outing/presentation/widgets/admin_outing_state_container.dart
+++ b/lib/features/outing/presentation/widgets/admin_outing_state_container.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/icons/app_icons.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
@@ -11,9 +10,22 @@ import 'package:goms/features/home/domain/enums/student_role_enum.dart';
 import 'package:goms/features/outing/presentation/widgets/admin_bottom_sheet.dart';
 
 final _adminOutingStudentRoleProvider =
-    StateProvider.autoDispose.family<StudentRole, (Object, StudentRole)>(
-      (ref, args) => args.$2,
-    );
+    NotifierProvider.autoDispose.family<
+      _AdminOutingStudentRoleNotifier,
+      StudentRole,
+      (Object, StudentRole)
+    >(_AdminOutingStudentRoleNotifier.new);
+
+class _AdminOutingStudentRoleNotifier extends Notifier<StudentRole> {
+  _AdminOutingStudentRoleNotifier(this.args);
+
+  final (Object, StudentRole) args;
+
+  @override
+  StudentRole build() => args.$2;
+
+  void setRole(StudentRole role) => state = role;
+}
 
 class AdminOutingStateContainer extends ConsumerStatefulWidget {
   final int memberId;
@@ -134,7 +146,7 @@ class _AdminOutingStateContainerState
                               _providerKey,
                             ).notifier,
                           )
-                          .state = newRole;
+                          .setRole(newRole);
                     },
                   ),
                 );

--- a/lib/features/outing/presentation/widgets/user_role_bottomsheet.dart
+++ b/lib/features/outing/presentation/widgets/user_role_bottomsheet.dart
@@ -1,7 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/core/network/network_exception.dart';
 import 'package:goms/core/theme/icons/app_icons.dart';
@@ -63,12 +62,29 @@ class _UserRoleBottomSheetStateModel {
 }
 
 final _userRoleBottomSheetStateProvider =
-    StateProvider.autoDispose.family<
+    NotifierProvider.autoDispose.family<
+      _UserRoleBottomSheetStateNotifier,
       _UserRoleBottomSheetStateModel,
       (Object, StudentRole)
-    >(
-      (ref, args) => _UserRoleBottomSheetStateModel.fromRole(args.$2),
-    );
+    >(_UserRoleBottomSheetStateNotifier.new);
+
+class _UserRoleBottomSheetStateNotifier
+    extends Notifier<_UserRoleBottomSheetStateModel> {
+  _UserRoleBottomSheetStateNotifier(this.args);
+
+  final (Object, StudentRole) args;
+
+  @override
+  _UserRoleBottomSheetStateModel build() =>
+      _UserRoleBottomSheetStateModel.fromRole(args.$2);
+
+  void update(
+    _UserRoleBottomSheetStateModel Function(_UserRoleBottomSheetStateModel state)
+        transform,
+  ) {
+    state = transform(state);
+  }
+}
 
 class UserRoleBottomSheet extends ConsumerStatefulWidget {
   const UserRoleBottomSheet({
@@ -310,7 +326,7 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
     final notifier = ref.read(
       _userRoleBottomSheetStateProvider(_providerKey).notifier,
     );
-    notifier.state = transform(notifier.state);
+    notifier.update(transform);
   }
 }
 

--- a/lib/features/outing/presentation/widgets/user_role_bottomsheet.dart
+++ b/lib/features/outing/presentation/widgets/user_role_bottomsheet.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/core/network/network_exception.dart';
 import 'package:goms/core/theme/icons/app_icons.dart';
@@ -17,6 +18,57 @@ import 'package:goms/features/home/domain/enums/student_role_enum.dart';
 import 'package:goms/features/member/data/providers/member_providers.dart';
 import 'package:goms/features/member/presentation/providers/student_council_members_provider.dart';
 import 'package:goms/features/outing/data/providers/outing_data_providers.dart';
+
+class _UserRoleBottomSheetStateModel {
+  const _UserRoleBottomSheetStateModel({
+    required this.isOutingBanned,
+    required this.isCouncil,
+    required this.isOuting,
+    required this.isSubmitting,
+  });
+
+  factory _UserRoleBottomSheetStateModel.fromRole(StudentRole role) {
+    return _UserRoleBottomSheetStateModel(
+      isOutingBanned: role == StudentRole.outingBanned,
+      isCouncil: role == StudentRole.council,
+      isOuting: false,
+      isSubmitting: false,
+    );
+  }
+
+  final bool isOutingBanned;
+  final bool isCouncil;
+  final bool isOuting;
+  final bool isSubmitting;
+
+  StudentRole get currentRole {
+    if (isCouncil) return StudentRole.council;
+    if (isOutingBanned) return StudentRole.outingBanned;
+    return StudentRole.student;
+  }
+
+  _UserRoleBottomSheetStateModel copyWith({
+    bool? isOutingBanned,
+    bool? isCouncil,
+    bool? isOuting,
+    bool? isSubmitting,
+  }) {
+    return _UserRoleBottomSheetStateModel(
+      isOutingBanned: isOutingBanned ?? this.isOutingBanned,
+      isCouncil: isCouncil ?? this.isCouncil,
+      isOuting: isOuting ?? this.isOuting,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+    );
+  }
+}
+
+final _userRoleBottomSheetStateProvider =
+    StateProvider.autoDispose.family<
+      _UserRoleBottomSheetStateModel,
+      (Object, StudentRole)
+    >(
+      (ref, args) => _UserRoleBottomSheetStateModel.fromRole(args.$2),
+    );
 
 class UserRoleBottomSheet extends ConsumerStatefulWidget {
   const UserRoleBottomSheet({
@@ -38,44 +90,41 @@ class UserRoleBottomSheet extends ConsumerStatefulWidget {
 }
 
 class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
-  bool isOutingBanned = false;
-  bool isCouncil = false;
-  bool isOuting = false;
-  bool _isSubmitting = false;
+  late final Object _providerIdentity;
 
-  StudentRole get _currentRole {
-    if (isCouncil) return StudentRole.council;
-    if (isOutingBanned) return StudentRole.outingBanned;
-    return StudentRole.student;
-  }
+  (Object, StudentRole) get _providerKey =>
+      (_providerIdentity, widget.studentRole);
 
   @override
   void initState() {
     super.initState();
-    isOutingBanned = widget.studentRole == StudentRole.outingBanned;
-    isCouncil = widget.studentRole == StudentRole.council;
+    _providerIdentity = Object();
   }
 
   @override
   Widget build(BuildContext context) {
+    final uiState = ref.watch(_userRoleBottomSheetStateProvider(_providerKey));
+
     return CommonBottomSheet(
       title: '유저 권한 변경',
       maxHeightRatio: widget.maxHeightRatio,
-      onClose: _isSubmitting ? null : () => Navigator.pop(context),
+      onClose: uiState.isSubmitting ? null : () => Navigator.pop(context),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (_currentRole == StudentRole.student)
+          if (uiState.currentRole == StudentRole.student)
             _UserRoleBottomSheetItem(
-              title: isOuting ? '강제외출 복귀' : '강제외출',
-              description: isOuting ? '학생을 강제외출 복귀를 시켜요' : '학생을 강제외출 시켜요',
+              title: uiState.isOuting ? '강제외출 복귀' : '강제외출',
+              description: uiState.isOuting
+                  ? '학생을 강제외출 복귀를 시켜요'
+                  : '학생을 강제외출 시켜요',
               trailing: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: IconButton(
-                  onPressed: _isSubmitting
+                  onPressed: uiState.isSubmitting
                       ? null
                       : () {
-                          if (isOuting) {
+                          if (uiState.isOuting) {
                             forcedOutingRelease(
                               context: context,
                               title: '강제외출 복귀',
@@ -91,14 +140,14 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
                             );
                           }
                         },
-                  icon: isOuting
+                  icon: uiState.isOuting
                       ? AppIcons.forceReturn()
                       : AppIcons.forcedOuting(),
                 ),
               ),
             ),
-          if (_currentRole == StudentRole.student ||
-              _currentRole == StudentRole.outingBanned) ...[
+          if (uiState.currentRole == StudentRole.student ||
+              uiState.currentRole == StudentRole.outingBanned) ...[
             AppGap.v12,
             _UserRoleBottomSheetItem(
               title: '외출금지',
@@ -107,11 +156,11 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
                 padding: const EdgeInsets.symmetric(horizontal: 8),
                 child: ToggleButton(
                   type: RoleEnum.admin,
-                  value: isOutingBanned,
-                  onChanged: _isSubmitting
+                  value: uiState.isOutingBanned,
+                  onChanged: uiState.isSubmitting
                       ? (_) {}
                       : (value) {
-                          if (isOutingBanned) {
+                          if (uiState.isOutingBanned) {
                             bannedOutingRelease(
                               context: context,
                               title: '외출금지',
@@ -143,8 +192,8 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
               padding: const EdgeInsets.symmetric(horizontal: 8),
               child: ToggleButton(
                 type: RoleEnum.admin,
-                value: isCouncil,
-                onChanged: _isSubmitting ? (_) {} : _updateCouncil,
+                value: uiState.isCouncil,
+                onChanged: uiState.isSubmitting ? (_) {} : _updateCouncil,
               ),
             ),
           ),
@@ -166,12 +215,12 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
               memberId: widget.memberId,
               studentRole: nextRole,
             );
-        setState(() {
-          isCouncil = value;
-          if (value) {
-            isOutingBanned = false;
-          }
-        });
+        _updateUiState(
+          (state) => state.copyWith(
+            isCouncil: value,
+            isOutingBanned: value ? false : state.isOutingBanned,
+          ),
+        );
         widget.onRoleChanged(nextRole);
       },
     );
@@ -192,12 +241,12 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
               memberId: widget.memberId,
               studentRole: nextRole,
             );
-        setState(() {
-          isOutingBanned = !isAllowed;
-          if (!isAllowed) {
-            isCouncil = false;
-          }
-        });
+        _updateUiState(
+          (state) => state.copyWith(
+            isOutingBanned: !isAllowed,
+            isCouncil: isAllowed ? state.isCouncil : false,
+          ),
+        );
         widget.onRoleChanged(nextRole);
       },
     );
@@ -210,9 +259,7 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
           ),
       onSuccess: () {
         if (!mounted) return;
-        setState(() {
-          isOuting = true;
-        });
+        _updateUiState((state) => state.copyWith(isOuting: true));
       },
     );
   }
@@ -224,9 +271,7 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
           ),
       onSuccess: () {
         if (!mounted) return;
-        setState(() {
-          isOuting = false;
-        });
+        _updateUiState((state) => state.copyWith(isOuting: false));
       },
     );
   }
@@ -235,11 +280,11 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
     Future<void> Function() action, {
     VoidCallback? onSuccess,
   }) async {
-    if (_isSubmitting) return;
+    if (ref.read(_userRoleBottomSheetStateProvider(_providerKey)).isSubmitting) {
+      return;
+    }
 
-    setState(() {
-      _isSubmitting = true;
-    });
+    _updateUiState((state) => state.copyWith(isSubmitting: true));
 
     try {
       await action();
@@ -249,11 +294,7 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
     } catch (_) {
       _showError('요청 처리 중 오류가 발생했습니다.');
     } finally {
-      if (mounted) {
-        setState(() {
-          _isSubmitting = false;
-        });
-      }
+      _updateUiState((state) => state.copyWith(isSubmitting: false));
     }
   }
 
@@ -261,6 +302,15 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
     ScaffoldMessenger.maybeOf(context)?.showSnackBar(
       SnackBar(content: Text(message)),
     );
+  }
+  void _updateUiState(
+    _UserRoleBottomSheetStateModel Function(_UserRoleBottomSheetStateModel state)
+        transform,
+  ) {
+    final notifier = ref.read(
+      _userRoleBottomSheetStateProvider(_providerKey).notifier,
+    );
+    notifier.state = transform(notifier.state);
   }
 }
 

--- a/lib/features/profile/presentation/screens/my_page_screen.dart
+++ b/lib/features/profile/presentation/screens/my_page_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:dio/dio.dart';
 import 'package:go_router/go_router.dart';
 import 'package:goms/core/network/network_exception.dart';
@@ -26,6 +27,9 @@ import 'package:goms/core/widgets/scaffolds/base_scaffold.dart';
 import 'package:goms/core/widgets/dialogs/goms_dialog.dart';
 import 'package:image_picker/image_picker.dart';
 
+final _profileImageUploadingProvider =
+    StateProvider.autoDispose.family<bool, Object>((ref, key) => false);
+
 class MyPageScreen extends ConsumerStatefulWidget {
   const MyPageScreen({super.key});
 
@@ -34,7 +38,13 @@ class MyPageScreen extends ConsumerStatefulWidget {
 }
 
 class _MyPageScreenState extends ConsumerState<MyPageScreen> {
-  bool _isUploadingProfileImage = false;
+  late final Object _providerKey;
+
+  @override
+  void initState() {
+    super.initState();
+    _providerKey = Object();
+  }
 
   void _showThemePicker(BuildContext context, AppThemeOption current) {
     showCupertinoModalPopup<void>(
@@ -114,7 +124,7 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
   }
 
   Future<void> _pickAndUploadProfileImage() async {
-    if (_isUploadingProfileImage) {
+    if (ref.read(_profileImageUploadingProvider(_providerKey))) {
       return;
     }
 
@@ -127,7 +137,7 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
       return;
     }
 
-    setState(() => _isUploadingProfileImage = true);
+    ref.read(_profileImageUploadingProvider(_providerKey).notifier).state = true;
     try {
       final imageUrl = await ref
           .read(memberRepositoryProvider)
@@ -165,14 +175,16 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
         SnackBar(content: Text(error.toString())),
       );
     } finally {
-      if (mounted) {
-        setState(() => _isUploadingProfileImage = false);
-      }
+      ref.read(_profileImageUploadingProvider(_providerKey).notifier).state =
+          false;
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final isUploadingProfileImage = ref.watch(
+      _profileImageUploadingProvider(_providerKey),
+    );
     final role = ref.watch(roleProvider);
     final currentMember = switch (ref.watch(currentMemberProvider)) {
       AsyncData(:final value) => value,
@@ -213,7 +225,7 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
               name: currentMember?.name ?? '정보 없음',
               profileImageUrl: currentMember?.profileImageUrl ?? '',
               onTapProfileImage: _pickAndUploadProfileImage,
-              isUploadingProfileImage: _isUploadingProfileImage,
+              isUploadingProfileImage: isUploadingProfileImage,
               grade: currentMember?.grade,
               major: currentMember?.department.name.toUpperCase(),
               lateCount: myOutingStatus?.lateCount,

--- a/lib/features/profile/presentation/screens/my_page_screen.dart
+++ b/lib/features/profile/presentation/screens/my_page_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:dio/dio.dart';
 import 'package:go_router/go_router.dart';
 import 'package:goms/core/network/network_exception.dart';
@@ -28,7 +27,22 @@ import 'package:goms/core/widgets/dialogs/goms_dialog.dart';
 import 'package:image_picker/image_picker.dart';
 
 final _profileImageUploadingProvider =
-    StateProvider.autoDispose.family<bool, Object>((ref, key) => false);
+    NotifierProvider.autoDispose.family<
+      _ProfileImageUploadingNotifier,
+      bool,
+      Object
+    >(_ProfileImageUploadingNotifier.new);
+
+class _ProfileImageUploadingNotifier extends Notifier<bool> {
+  _ProfileImageUploadingNotifier(this.key);
+
+  final Object key;
+
+  @override
+  bool build() => false;
+
+  void setUploading(bool value) => state = value;
+}
 
 class MyPageScreen extends ConsumerStatefulWidget {
   const MyPageScreen({super.key});
@@ -137,7 +151,9 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
       return;
     }
 
-    ref.read(_profileImageUploadingProvider(_providerKey).notifier).state = true;
+    ref
+        .read(_profileImageUploadingProvider(_providerKey).notifier)
+        .setUploading(true);
     try {
       final imageUrl = await ref
           .read(memberRepositoryProvider)
@@ -175,8 +191,9 @@ class _MyPageScreenState extends ConsumerState<MyPageScreen> {
         SnackBar(content: Text(error.toString())),
       );
     } finally {
-      ref.read(_profileImageUploadingProvider(_providerKey).notifier).state =
-          false;
+      ref
+          .read(_profileImageUploadingProvider(_providerKey).notifier)
+          .setUploading(false);
     }
   }
 

--- a/lib/features/qr/presentation/screens/qr_issue_screen.dart
+++ b/lib/features/qr/presentation/screens/qr_issue_screen.dart
@@ -15,6 +15,27 @@ import 'package:goms/features/qr/domain/entities/issued_qr_entity.dart';
 import 'package:goms/features/qr/presentation/providers/issued_qr_provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
+final _qrRemainingProvider =
+    StreamProvider.autoDispose.family<Duration, IssuedQrEntity>((ref, value) async* {
+      Duration remaining() {
+        const qrLifetime = Duration(minutes: 5);
+        final serverExpiresAt = DateTime.fromMillisecondsSinceEpoch(
+          value.exp * 1000,
+          isUtc: true,
+        ).toLocal();
+        final clientExpiresAt = value.issuedAt.add(qrLifetime);
+        final expiresAt = serverExpiresAt.isBefore(clientExpiresAt)
+            ? serverExpiresAt
+            : clientExpiresAt;
+        final diff = expiresAt.difference(DateTime.now());
+        return diff.isNegative ? Duration.zero : diff;
+      }
+
+      yield remaining();
+      final timer = Stream.periodic(const Duration(seconds: 1), (_) => remaining());
+      yield* timer;
+    });
+
 class QrIssueScreen extends ConsumerWidget {
   const QrIssueScreen({super.key});
 
@@ -56,7 +77,7 @@ class QrIssueScreen extends ConsumerWidget {
   }
 }
 
-class _QrIssuedContent extends StatefulWidget {
+class _QrIssuedContent extends ConsumerWidget {
   const _QrIssuedContent({
     required this.value,
     required this.onRefresh,
@@ -65,75 +86,19 @@ class _QrIssuedContent extends StatefulWidget {
   final IssuedQrEntity value;
   final VoidCallback onRefresh;
 
-  @override
-  State<_QrIssuedContent> createState() => _QrIssuedContentState();
-}
-
-class _QrIssuedContentState extends State<_QrIssuedContent> {
-  static const Duration _qrLifetime = Duration(minutes: 5);
-
-  Timer? _timer;
-  late Duration _remaining;
-
-  DateTime get _expiresAt {
-    final serverExpiresAt = DateTime.fromMillisecondsSinceEpoch(
-      widget.value.exp * 1000,
-      isUtc: true,
-    ).toLocal();
-    final clientExpiresAt = widget.value.issuedAt.add(_qrLifetime);
-
-    return serverExpiresAt.isBefore(clientExpiresAt)
-        ? serverExpiresAt
-        : clientExpiresAt;
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _remaining = _calculateRemaining();
-    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-      if (!mounted) return;
-      setState(() {
-        _remaining = _calculateRemaining();
-      });
-    });
-  }
-
-  @override
-  void didUpdateWidget(covariant _QrIssuedContent oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.value.uuid != widget.value.uuid ||
-        oldWidget.value.exp != widget.value.exp ||
-        oldWidget.value.issuedAt != widget.value.issuedAt) {
-      _remaining = _calculateRemaining();
-    }
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
-
-  Duration _calculateRemaining() {
-    final diff = _expiresAt.difference(DateTime.now());
-    if (diff.isNegative) {
-      return Duration.zero;
-    }
-    return diff;
-  }
-
-  String get _remainingText {
-    final minutes = _remaining.inMinutes.remainder(60).toString().padLeft(2, '0');
-    final seconds = _remaining.inSeconds.remainder(60).toString().padLeft(2, '0');
+  String _remainingText(WidgetRef ref) {
+    final remaining =
+        ref.watch(_qrRemainingProvider(value)).asData?.value ?? Duration.zero;
+    final minutes = remaining.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = remaining.inSeconds.remainder(60).toString().padLeft(2, '0');
     return '$minutes분 $seconds초';
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final qrPayload = jsonEncode({
-      'uuid': widget.value.uuid,
-      'exp': widget.value.exp,
+      'uuid': value.uuid,
+      'exp': value.exp,
     });
 
     return LayoutBuilder(
@@ -191,7 +156,7 @@ class _QrIssuedContentState extends State<_QrIssuedContent> {
                     ),
                     AppGap.v4,
                     Text(
-                      _remainingText,
+                      _remainingText(ref),
                       style: AppTextStyles.title2.withColor(context.mainTextColor),
                       textAlign: TextAlign.center,
                     ),
@@ -199,7 +164,7 @@ class _QrIssuedContentState extends State<_QrIssuedContent> {
                 ),
               ),
             ),
-            ConfirmButton(text: 'QR 다시 발급하기', onPressed: widget.onRefresh),
+            ConfirmButton(text: 'QR 다시 발급하기', onPressed: onRefresh),
           ],
         );
       },

--- a/lib/features/report/presentation/screens/admin_report_detail_screen.dart
+++ b/lib/features/report/presentation/screens/admin_report_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
@@ -11,6 +12,9 @@ import 'package:goms/features/map/review/domain/enums/report_status.dart';
 import 'package:goms/features/report/domain/entities/report_detail_entity.dart';
 import 'package:goms/features/report/presentation/providers/admin_report_providers.dart';
 import 'package:intl/intl.dart';
+
+final _reportResolveSubmittingProvider =
+    StateProvider.autoDispose.family<bool, int>((ref, reportId) => false);
 
 class AdminReportDetailScreen extends ConsumerStatefulWidget {
   const AdminReportDetailScreen({
@@ -27,17 +31,18 @@ class AdminReportDetailScreen extends ConsumerStatefulWidget {
 
 class _AdminReportDetailScreenState
     extends ConsumerState<AdminReportDetailScreen> {
-  bool _isSubmitting = false;
-
   @override
   Widget build(BuildContext context) {
     final detailAsync = ref.watch(reportDetailProvider(widget.reportId));
+    final isSubmitting = ref.watch(
+      _reportResolveSubmittingProvider(widget.reportId),
+    );
 
     return BaseScaffold(
       showAppBar: true,
       role: RoleEnum.admin,
       body: detailAsync.when(
-        data: (detail) => _buildContent(context, detail),
+        data: (detail) => _buildContent(context, detail, isSubmitting),
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, _) => Center(
           child: Column(
@@ -64,7 +69,11 @@ class _AdminReportDetailScreenState
     );
   }
 
-  Widget _buildContent(BuildContext context, ReportDetailEntity detail) {
+  Widget _buildContent(
+    BuildContext context,
+    ReportDetailEntity detail,
+    bool isSubmitting,
+  ) {
     final reportCreatedAt = _formatDateTime(detail.reportCreatedAt);
     final reviewCreatedAt = _formatDateTime(detail.reviewCreatedAt);
 
@@ -131,7 +140,7 @@ class _AdminReportDetailScreenState
                   label: '기각',
                   backgroundColor: context.buttonColor,
                   foregroundColor: context.sub2Color,
-                  onPressed: _isSubmitting
+                  onPressed: isSubmitting
                       ? null
                       : () => _resolve(ReportStatus.rejected),
                 ),
@@ -139,10 +148,10 @@ class _AdminReportDetailScreenState
               AppGap.h12,
               Expanded(
                 child: _ActionButton(
-                  label: _isSubmitting ? '처리 중...' : '리뷰 삭제',
+                  label: isSubmitting ? '처리 중...' : '리뷰 삭제',
                   backgroundColor: AppColors.negative,
                   foregroundColor: Colors.white,
-                  onPressed: _isSubmitting
+                  onPressed: isSubmitting
                       ? null
                       : () => _resolve(ReportStatus.approved),
                 ),
@@ -159,7 +168,8 @@ class _AdminReportDetailScreenState
   }
 
   Future<void> _resolve(ReportStatus status) async {
-    setState(() => _isSubmitting = true);
+    ref.read(_reportResolveSubmittingProvider(widget.reportId).notifier).state =
+        true;
     try {
       await ref.read(pendingReportsProvider.notifier).resolve(
             reportId: widget.reportId,
@@ -180,9 +190,9 @@ class _AdminReportDetailScreenState
         SnackBar(content: Text(error.message)),
       );
     } finally {
-      if (mounted) {
-        setState(() => _isSubmitting = false);
-      }
+      ref
+          .read(_reportResolveSubmittingProvider(widget.reportId).notifier)
+          .state = false;
     }
   }
 }

--- a/lib/features/report/presentation/screens/admin_report_detail_screen.dart
+++ b/lib/features/report/presentation/screens/admin_report_detail_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
@@ -14,7 +13,22 @@ import 'package:goms/features/report/presentation/providers/admin_report_provide
 import 'package:intl/intl.dart';
 
 final _reportResolveSubmittingProvider =
-    StateProvider.autoDispose.family<bool, int>((ref, reportId) => false);
+    NotifierProvider.autoDispose.family<
+      _ReportResolveSubmittingNotifier,
+      bool,
+      int
+    >(_ReportResolveSubmittingNotifier.new);
+
+class _ReportResolveSubmittingNotifier extends Notifier<bool> {
+  _ReportResolveSubmittingNotifier(this.reportId);
+
+  final int reportId;
+
+  @override
+  bool build() => false;
+
+  void setSubmitting(bool value) => state = value;
+}
 
 class AdminReportDetailScreen extends ConsumerStatefulWidget {
   const AdminReportDetailScreen({
@@ -168,8 +182,9 @@ class _AdminReportDetailScreenState
   }
 
   Future<void> _resolve(ReportStatus status) async {
-    ref.read(_reportResolveSubmittingProvider(widget.reportId).notifier).state =
-        true;
+    ref
+        .read(_reportResolveSubmittingProvider(widget.reportId).notifier)
+        .setSubmitting(true);
     try {
       await ref.read(pendingReportsProvider.notifier).resolve(
             reportId: widget.reportId,
@@ -192,7 +207,7 @@ class _AdminReportDetailScreenState
     } finally {
       ref
           .read(_reportResolveSubmittingProvider(widget.reportId).notifier)
-          .state = false;
+          .setSubmitting(false);
     }
   }
 }

--- a/lib/features/report/presentation/screens/admin_report_list_screen.dart
+++ b/lib/features/report/presentation/screens/admin_report_list_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:go_router/go_router.dart';
 import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/core/router/route_path.dart';
@@ -18,6 +19,11 @@ import 'package:goms/features/report/presentation/providers/admin_report_provide
 import 'package:goms/features/report/presentation/widgets/report_filter_bottom_sheet.dart';
 import 'package:intl/intl.dart';
 
+final _reportSearchQueryProvider =
+    StateProvider.autoDispose.family<String, Object>((ref, key) => '');
+final _reportStatusFilterProvider =
+    StateProvider.autoDispose.family<ReportStatus?, Object>((ref, key) => null);
+
 class AdminReportListScreen extends ConsumerStatefulWidget {
   const AdminReportListScreen({super.key});
 
@@ -28,12 +34,12 @@ class AdminReportListScreen extends ConsumerStatefulWidget {
 
 class _AdminReportListScreenState extends ConsumerState<AdminReportListScreen> {
   final TextEditingController _searchController = TextEditingController();
-  String _query = '';
-  ReportStatus? _reportStatusFilter;
+  late final Object _providerKey;
 
   @override
   void initState() {
     super.initState();
+    _providerKey = Object();
     Future.microtask(() {
       ref.invalidate(pendingReportsProvider);
       ref.invalidate(resolvedReportsProvider);
@@ -52,6 +58,8 @@ class _AdminReportListScreenState extends ConsumerState<AdminReportListScreen> {
   Widget build(BuildContext context) {
     final pendingReportsAsync = ref.watch(pendingReportsProvider);
     final resolvedReportsAsync = ref.watch(resolvedReportsProvider);
+    final query = ref.watch(_reportSearchQueryProvider(_providerKey));
+    final reportStatusFilter = ref.watch(_reportStatusFilterProvider(_providerKey));
 
     return BaseScaffold(
       showAppBar: true,
@@ -60,23 +68,21 @@ class _AdminReportListScreenState extends ConsumerState<AdminReportListScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _ReportTile(
-            reportStatusFilter: _reportStatusFilter,
-            onResetFilter: () {
-              setState(() {
-                _reportStatusFilter = null;
-              });
-            },
-            onApplyFilter: (selection) {
-              setState(() {
-                _reportStatusFilter = selection.reportStatus;
-              });
-            },
+            reportStatusFilter: reportStatusFilter,
+            onResetFilter: () => ref
+                .read(_reportStatusFilterProvider(_providerKey).notifier)
+                .state = null,
+            onApplyFilter: (selection) => ref
+                .read(_reportStatusFilterProvider(_providerKey).notifier)
+                .state = selection.reportStatus,
           ),
           AppGap.v24,
           SearchStudentField(
             controller: _searchController,
             hintText: '학생 검색',
-            onChanged: (value) => setState(() => _query = value),
+            onChanged: (value) =>
+                ref.read(_reportSearchQueryProvider(_providerKey).notifier).state =
+                    value,
           ),
           AppGap.v16,
           Text(
@@ -97,8 +103,8 @@ class _AdminReportListScreenState extends ConsumerState<AdminReportListScreen> {
               child: _ReportListBody(
                 pendingReportsAsync: pendingReportsAsync,
                 resolvedReportsAsync: resolvedReportsAsync,
-                query: _query,
-                reportStatusFilter: _reportStatusFilter,
+                query: query,
+                reportStatusFilter: reportStatusFilter,
               ),
             ),
           ),

--- a/lib/features/report/presentation/screens/admin_report_list_screen.dart
+++ b/lib/features/report/presentation/screens/admin_report_list_screen.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:go_router/go_router.dart';
 import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/core/router/route_path.dart';
@@ -20,9 +19,37 @@ import 'package:goms/features/report/presentation/widgets/report_filter_bottom_s
 import 'package:intl/intl.dart';
 
 final _reportSearchQueryProvider =
-    StateProvider.autoDispose.family<String, Object>((ref, key) => '');
+    NotifierProvider.autoDispose.family<_ReportSearchQueryNotifier, String, Object>(
+      _ReportSearchQueryNotifier.new,
+    );
 final _reportStatusFilterProvider =
-    StateProvider.autoDispose.family<ReportStatus?, Object>((ref, key) => null);
+    NotifierProvider.autoDispose.family<
+      _ReportStatusFilterNotifier,
+      ReportStatus?,
+      Object
+    >(_ReportStatusFilterNotifier.new);
+
+class _ReportSearchQueryNotifier extends Notifier<String> {
+  _ReportSearchQueryNotifier(this.key);
+
+  final Object key;
+
+  @override
+  String build() => '';
+
+  void setQuery(String value) => state = value;
+}
+
+class _ReportStatusFilterNotifier extends Notifier<ReportStatus?> {
+  _ReportStatusFilterNotifier(this.key);
+
+  final Object key;
+
+  @override
+  ReportStatus? build() => null;
+
+  void setStatus(ReportStatus? value) => state = value;
+}
 
 class AdminReportListScreen extends ConsumerStatefulWidget {
   const AdminReportListScreen({super.key});
@@ -71,18 +98,18 @@ class _AdminReportListScreenState extends ConsumerState<AdminReportListScreen> {
             reportStatusFilter: reportStatusFilter,
             onResetFilter: () => ref
                 .read(_reportStatusFilterProvider(_providerKey).notifier)
-                .state = null,
+                .setStatus(null),
             onApplyFilter: (selection) => ref
                 .read(_reportStatusFilterProvider(_providerKey).notifier)
-                .state = selection.reportStatus,
+                .setStatus(selection.reportStatus),
           ),
           AppGap.v24,
           SearchStudentField(
             controller: _searchController,
             hintText: '학생 검색',
-            onChanged: (value) =>
-                ref.read(_reportSearchQueryProvider(_providerKey).notifier).state =
-                    value,
+            onChanged: (value) => ref
+                .read(_reportSearchQueryProvider(_providerKey).notifier)
+                .setQuery(value),
           ),
           AppGap.v16,
           Text(

--- a/lib/features/report/presentation/widgets/report_filter_bottom_sheet.dart
+++ b/lib/features/report/presentation/widgets/report_filter_bottom_sheet.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
@@ -27,9 +26,22 @@ class ReportFilterSelection {
 }
 
 final _reportFilterSelectionProvider =
-    StateProvider.autoDispose.family<ReportFilterSelection, (Object, ReportFilterSelection)>(
-      (ref, args) => args.$2,
-    );
+    NotifierProvider.autoDispose.family<
+      _ReportFilterSelectionNotifier,
+      ReportFilterSelection,
+      (Object, ReportFilterSelection)
+    >(_ReportFilterSelectionNotifier.new);
+
+class _ReportFilterSelectionNotifier extends Notifier<ReportFilterSelection> {
+  _ReportFilterSelectionNotifier(this.args);
+
+  final (Object, ReportFilterSelection) args;
+
+  @override
+  ReportFilterSelection build() => args.$2;
+
+  void setSelection(ReportFilterSelection selection) => state = selection;
+}
 
 class ReportFilterBottomSheet extends ConsumerStatefulWidget {
   const ReportFilterBottomSheet({
@@ -132,15 +144,17 @@ class _ReportFilterBottomSheetState extends ConsumerState<ReportFilterBottomShee
   }
 
   void _handleReset() {
-    ref.read(_reportFilterSelectionProvider(_providerKey).notifier).state =
-        const ReportFilterSelection();
+    ref
+        .read(_reportFilterSelectionProvider(_providerKey).notifier)
+        .setSelection(const ReportFilterSelection());
     widget.onReset?.call();
     Navigator.pop(context);
   }
 
   void _updateSelection(ReportFilterSelection selection) {
-    ref.read(_reportFilterSelectionProvider(_providerKey).notifier).state =
-        selection;
+    ref
+        .read(_reportFilterSelectionProvider(_providerKey).notifier)
+        .setSelection(selection);
     _notifySelectionChanged(selection);
   }
 

--- a/lib/features/report/presentation/widgets/report_filter_bottom_sheet.dart
+++ b/lib/features/report/presentation/widgets/report_filter_bottom_sheet.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
@@ -13,9 +15,23 @@ class ReportFilterSelection {
   });
 
   final ReportStatus? reportStatus;
+
+  ReportFilterSelection copyWith({
+    ReportStatus? reportStatus,
+    bool clearReportStatus = false,
+  }) {
+    return ReportFilterSelection(
+      reportStatus: clearReportStatus ? null : (reportStatus ?? this.reportStatus),
+    );
+  }
 }
 
-class ReportFilterBottomSheet extends StatefulWidget {
+final _reportFilterSelectionProvider =
+    StateProvider.autoDispose.family<ReportFilterSelection, (Object, ReportFilterSelection)>(
+      (ref, args) => args.$2,
+    );
+
+class ReportFilterBottomSheet extends ConsumerStatefulWidget {
   const ReportFilterBottomSheet({
     super.key,
     this.initialSelection = const ReportFilterSelection(),
@@ -28,21 +44,26 @@ class ReportFilterBottomSheet extends StatefulWidget {
   final VoidCallback? onReset;
 
   @override
-  State<ReportFilterBottomSheet> createState() =>
+  ConsumerState<ReportFilterBottomSheet> createState() =>
       _ReportFilterBottomSheetState();
 }
 
-class _ReportFilterBottomSheetState extends State<ReportFilterBottomSheet> {
-  ReportStatus? _reportStatus;
+class _ReportFilterBottomSheetState extends ConsumerState<ReportFilterBottomSheet> {
+  late final Object _providerIdentity;
+
+  (Object, ReportFilterSelection) get _providerKey =>
+      (_providerIdentity, widget.initialSelection);
 
   @override
   void initState() {
     super.initState();
-    _reportStatus = widget.initialSelection.reportStatus;
+    _providerIdentity = Object();
   }
 
   @override
   Widget build(BuildContext context) {
+    final selection = ref.watch(_reportFilterSelectionProvider(_providerKey));
+
     return CommonBottomSheet(
       title: '필터',
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
@@ -62,22 +83,26 @@ class _ReportFilterBottomSheetState extends State<ReportFilterBottomSheet> {
               Expanded(
                 child: CategoryChip(
                   category: '처리전',
-                  selected: _reportStatus == ReportStatus.pending,
-                  onChanged: (selected) => setState(() {
-                    _reportStatus = selected ? ReportStatus.pending : null;
-                    _notifySelectionChanged();
-                  }),
+                  selected: selection.reportStatus == ReportStatus.pending,
+                  onChanged: (selected) => _updateSelection(
+                    selection.copyWith(
+                      reportStatus: selected ? ReportStatus.pending : null,
+                      clearReportStatus: !selected,
+                    ),
+                  ),
                 ),
               ),
               AppGap.h8,
               Expanded(
                 child: CategoryChip(
                   category: '처리완료',
-                  selected: _reportStatus == ReportStatus.approved,
-                  onChanged: (selected) => setState(() {
-                    _reportStatus = selected ? ReportStatus.approved : null;
-                    _notifySelectionChanged();
-                  }),
+                  selected: selection.reportStatus == ReportStatus.approved,
+                  onChanged: (selected) => _updateSelection(
+                    selection.copyWith(
+                      reportStatus: selected ? ReportStatus.approved : null,
+                      clearReportStatus: !selected,
+                    ),
+                  ),
                 ),
               ),
             ],
@@ -107,16 +132,19 @@ class _ReportFilterBottomSheetState extends State<ReportFilterBottomSheet> {
   }
 
   void _handleReset() {
-    setState(() {
-      _reportStatus = null;
-    });
+    ref.read(_reportFilterSelectionProvider(_providerKey).notifier).state =
+        const ReportFilterSelection();
     widget.onReset?.call();
     Navigator.pop(context);
   }
 
-  void _notifySelectionChanged() {
-    widget.onApply?.call(
-      ReportFilterSelection(reportStatus: _reportStatus),
-    );
+  void _updateSelection(ReportFilterSelection selection) {
+    ref.read(_reportFilterSelectionProvider(_providerKey).notifier).state =
+        selection;
+    _notifySelectionChanged(selection);
+  }
+
+  void _notifySelectionChanged(ReportFilterSelection selection) {
+    widget.onApply?.call(selection);
   }
 }

--- a/test/integration/auth_widgets_integration_test.dart
+++ b/test/integration/auth_widgets_integration_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/core/widgets/buttons/toggle_button.dart';
@@ -9,7 +8,16 @@ import 'package:goms/core/widgets/text_fields/password_text_field.dart';
 import '../test_app.dart';
 
 final _authHarnessToggleProvider =
-    StateProvider.autoDispose<bool>((ref) => false);
+    NotifierProvider.autoDispose<_AuthHarnessToggleNotifier, bool>(
+      _AuthHarnessToggleNotifier.new,
+    );
+
+class _AuthHarnessToggleNotifier extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  void setEnabled(bool value) => state = value;
+}
 
 void main() {
   const emailFieldKey = Key('email_field');
@@ -72,7 +80,7 @@ class _AuthFormHarness extends ConsumerWidget {
             type: RoleEnum.user,
             value: isUserEnabled,
             onChanged: (value) =>
-                ref.read(_authHarnessToggleProvider.notifier).state = value,
+                ref.read(_authHarnessToggleProvider.notifier).setEnabled(value),
           ),
         ],
       ),

--- a/test/integration/auth_widgets_integration_test.dart
+++ b/test/integration/auth_widgets_integration_test.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/core/widgets/buttons/toggle_button.dart';
 import 'package:goms/core/widgets/text_fields/email_text_field.dart';
 import 'package:goms/core/widgets/text_fields/password_text_field.dart';
 import '../test_app.dart';
+
+final _authHarnessToggleProvider =
+    StateProvider.autoDispose<bool>((ref) => false);
 
 void main() {
   const emailFieldKey = Key('email_field');
@@ -14,9 +19,11 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      const _AuthFormHarness(
-        emailFieldKey: emailFieldKey,
-        passwordFieldKey: passwordFieldKey,
+      buildTestApp(
+        const _AuthFormHarness(
+          emailFieldKey: emailFieldKey,
+          passwordFieldKey: passwordFieldKey,
+        ),
       ),
     );
 
@@ -41,7 +48,7 @@ void main() {
   });
 }
 
-class _AuthFormHarness extends StatefulWidget {
+class _AuthFormHarness extends ConsumerWidget {
   const _AuthFormHarness({
     required this.emailFieldKey,
     required this.passwordFieldKey,
@@ -51,34 +58,23 @@ class _AuthFormHarness extends StatefulWidget {
   final Key passwordFieldKey;
 
   @override
-  State<_AuthFormHarness> createState() => _AuthFormHarnessState();
-}
-
-class _AuthFormHarnessState extends State<_AuthFormHarness> {
-  bool isUserEnabled = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return buildTestApp(
-      Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            EmailTextField(key: widget.emailFieldKey),
-            const SizedBox(height: 16),
-            PasswordTextField(key: widget.passwordFieldKey),
-            const SizedBox(height: 16),
-            ToggleButton(
-              type: RoleEnum.user,
-              value: isUserEnabled,
-              onChanged: (value) {
-                setState(() {
-                  isUserEnabled = value;
-                });
-              },
-            ),
-          ],
-        ),
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isUserEnabled = ref.watch(_authHarnessToggleProvider);
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        children: [
+          EmailTextField(key: emailFieldKey),
+          const SizedBox(height: 16),
+          PasswordTextField(key: passwordFieldKey),
+          const SizedBox(height: 16),
+          ToggleButton(
+            type: RoleEnum.user,
+            value: isUserEnabled,
+            onChanged: (value) =>
+                ref.read(_authHarnessToggleProvider.notifier).state = value,
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## 💡 개요
setState로 관리하던 화면 내부 상태를 Riverpod 기반 상태로 전환해 상태 관리 방식을 일관되게 정리했습니다.

## 🔗 관련 이슈
Closes #87

## 📃 작업내용
- 공용 `CategoryChip`과 신고/멤버 필터 바텀시트의 선택 상태를 Riverpod으로 전환했습니다.
- 로그인 버튼 활성화, 프로필 이미지 업로드, 외출 권한 변경 등 화면 내부 UI 상태를 Riverpod provider로 분리했습니다.
- QR 만료 카운트다운과 카카오 맵 준비 상태를 Riverpod 기반 상태로 치환했습니다.
- 인증 위젯 통합 테스트 하네스도 Riverpod 상태를 사용하도록 정리했습니다.
- `lib`, `test` 기준 `setState` 사용처가 남지 않도록 정리했습니다.

## 🔍 테스트 방법
- `flutter analyze`
- `flutter test test/integration/auth_widgets_integration_test.dart test/widget/qr_issue_screen_widget_test.dart test/widget/my_page_screen_widget_test.dart test/widget/admin_outing_state_screen_widget_test.dart`

## 🖼️ 스크린샷
- 없음

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 기존 기능이 정상적으로 작동하는지 확인했습니다.
