### PR TITLE
🔀 :: (#97) - 지도 추천 및 내 리뷰 API 연동

### DIFF
--- a/lib/features/map/data/datasources/recommended_place_remote_datasource.dart
+++ b/lib/features/map/data/datasources/recommended_place_remote_datasource.dart
@@ -1,85 +1,96 @@
 import 'package:dio/dio.dart';
+import 'package:goms/features/map/data/response/my_review_count_response.dart';
+import 'package:goms/features/map/data/response/my_review_list_response.dart';
 import 'package:goms/features/map/data/response/place_review_list_response.dart';
+import 'package:goms/features/map/data/response/place_recommend_response.dart';
+import 'package:goms/features/map/data/response/recommended_place_count_response.dart';
 import 'package:goms/features/map/data/response/recommended_place_response.dart';
 import 'package:goms/features/map/data/response/recommended_places_response.dart';
+import 'package:retrofit/retrofit.dart';
 
-class RecommendedPlaceRemoteDataSource {
-  const RecommendedPlaceRemoteDataSource(this._dio);
+part 'recommended_place_remote_datasource.g.dart';
 
-  final Dio _dio;
+@RestApi()
+abstract class RecommendedPlaceRemoteDataSource {
+  factory RecommendedPlaceRemoteDataSource(Dio dio, {String? baseUrl}) =
+      _RecommendedPlaceRemoteDataSource;
 
-  Future<RecommendedPlacesResponse> getPlaces() async {
-    final response = await _dio.get<Map<String, dynamic>>(
-      '/api/v3/place',
-    );
-    return RecommendedPlacesResponse.fromJson(response.data ?? const {});
-  }
+  @GET('/api/v3/place')
+  Future<RecommendedPlacesResponse> getPlaces();
 
-  Future<RecommendedPlacesResponse> getHotPlaces({int? days}) async {
-    final response = await _dio.get<Map<String, dynamic>>(
-      '/api/v3/place/hot-place',
-      queryParameters: days == null ? null : {'days': days},
-    );
-    return RecommendedPlacesResponse.fromJson(response.data ?? const {});
-  }
+  @GET('/api/v3/place/hot-place')
+  Future<RecommendedPlacesResponse> getHotPlaces({
+    @Query('days') int? days,
+  });
 
-  Future<RecommendedPlacesResponse> getRecommendedPlaces() async {
-    final response = await _dio.get<Map<String, dynamic>>(
-      '/api/v3/place/recommended',
-    );
-    return RecommendedPlacesResponse.fromJson(response.data ?? const {});
-  }
+  @GET('/api/v3/place/recommended')
+  Future<RecommendedPlacesResponse> getRecommendedPlaces();
 
+  @GET('/api/v3/place/recommended/count')
+  Future<RecommendedPlaceCountResponse> getRecommendedPlacesCountRaw();
+
+  @GET('/api/v3/place/search')
+  Future<RecommendedPlacesResponse> searchPlaces(
+      @Query('keyword') String keyword);
+
+  @GET('/api/v3/place/{placeId}')
+  Future<RecommendedPlaceResponse> getPlaceDetail(@Path('placeId') int placeId);
+
+  @GET('/api/v3/place/review/{placeId}')
+  Future<PlaceReviewListResponse> getPlaceReviews(@Path('placeId') int placeId);
+
+  @POST('/api/v3/place/recommend/{placeId}')
+  Future<PlaceRecommendResponse> recommendPlaceRaw(@Path('placeId') int placeId);
+
+  @DELETE('/api/v3/place/recommend/{placeId}')
+  Future<PlaceRecommendResponse> unRecommendPlaceRaw(
+    @Path('placeId') int placeId,
+  );
+
+  @POST('/api/v3/review/{placeId}')
+  Future<void> createReviewRaw(
+    @Path('placeId') int placeId,
+    @Body() Map<String, dynamic> body,
+  );
+
+  @GET('/api/v3/review/me')
+  Future<MyReviewListResponse> getMyReviews();
+
+  @GET('/api/v3/review/count')
+  Future<MyReviewCountResponse> getMyReviewCountRaw();
+
+  @DELETE('/api/v3/review/{reviewId}')
+  Future<void> deleteReview(@Path('reviewId') int reviewId);
+}
+
+extension RecommendedPlaceRemoteDataSourceX on RecommendedPlaceRemoteDataSource {
   Future<int> getRecommendedPlacesCount() async {
-    final response = await _dio.get<Map<String, dynamic>>(
-      '/api/v3/place/recommended/count',
-    );
-    return (response.data?['recommendCount'] as num?)?.toInt() ?? 0;
-  }
-
-  Future<RecommendedPlacesResponse> searchPlaces(String keyword) async {
-    final response = await _dio.get<Map<String, dynamic>>(
-      '/api/v3/place/search',
-      queryParameters: {'keyword': keyword},
-    );
-    return RecommendedPlacesResponse.fromJson(response.data ?? const {});
-  }
-
-  Future<RecommendedPlaceResponse> getPlaceDetail(int placeId) async {
-    final response = await _dio.get<Map<String, dynamic>>(
-      '/api/v3/place/$placeId',
-    );
-    return RecommendedPlaceResponse.fromJson(response.data ?? const {});
-  }
-
-  Future<PlaceReviewListResponse> getPlaceReviews(int placeId) async {
-    final response = await _dio.get<Map<String, dynamic>>(
-      '/api/v3/place/review/$placeId',
-    );
-    return PlaceReviewListResponse.fromJson(response.data ?? const {});
+    final response = await getRecommendedPlacesCountRaw();
+    return response.recommendCount;
   }
 
   Future<bool> recommendPlace(int placeId) async {
-    final response = await _dio.post<Map<String, dynamic>>(
-      '/api/v3/place/recommend/$placeId',
-    );
-    return response.data?['recommended'] as bool? ?? true;
+    final response = await recommendPlaceRaw(placeId);
+    return response.recommended;
   }
 
   Future<bool> unRecommendPlace(int placeId) async {
-    final response = await _dio.delete<Map<String, dynamic>>(
-      '/api/v3/place/recommend/$placeId',
-    );
-    return response.data?['recommended'] as bool? ?? false;
+    final response = await unRecommendPlaceRaw(placeId);
+    return response.recommended;
   }
 
   Future<void> createReview({
     required int placeId,
     required String content,
-  }) async {
-    await _dio.post<Map<String, dynamic>>(
-      '/api/v3/review/$placeId',
-      data: {'content': content},
+  }) {
+    return createReviewRaw(
+      placeId,
+      <String, dynamic>{'content': content},
     );
+  }
+
+  Future<int> getMyReviewCount() async {
+    final response = await getMyReviewCountRaw();
+    return response.count;
   }
 }

--- a/lib/features/map/data/datasources/recommended_place_remote_datasource.g.dart
+++ b/lib/features/map/data/datasources/recommended_place_remote_datasource.g.dart
@@ -1,0 +1,392 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recommended_place_remote_datasource.dart';
+
+// dart format off
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+
+class _RecommendedPlaceRemoteDataSource
+    implements RecommendedPlaceRemoteDataSource {
+  _RecommendedPlaceRemoteDataSource(
+    this._dio, {
+    this.baseUrl,
+    this.errorLogger,
+  });
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<RecommendedPlacesResponse> getPlaces() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<RecommendedPlacesResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/place',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late RecommendedPlacesResponse _value;
+    try {
+      _value = RecommendedPlacesResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<RecommendedPlacesResponse> getHotPlaces({int? days}) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'days': days};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<RecommendedPlacesResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/place/hot-place',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late RecommendedPlacesResponse _value;
+    try {
+      _value = RecommendedPlacesResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<RecommendedPlacesResponse> getRecommendedPlaces() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<RecommendedPlacesResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/place/recommended',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late RecommendedPlacesResponse _value;
+    try {
+      _value = RecommendedPlacesResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<RecommendedPlaceCountResponse> getRecommendedPlacesCountRaw() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<RecommendedPlaceCountResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/place/recommended/count',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late RecommendedPlaceCountResponse _value;
+    try {
+      _value = RecommendedPlaceCountResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<RecommendedPlacesResponse> searchPlaces(String keyword) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'keyword': keyword};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<RecommendedPlacesResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/place/search',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late RecommendedPlacesResponse _value;
+    try {
+      _value = RecommendedPlacesResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<RecommendedPlaceResponse> getPlaceDetail(int placeId) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<RecommendedPlaceResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/place/${placeId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late RecommendedPlaceResponse _value;
+    try {
+      _value = RecommendedPlaceResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<PlaceReviewListResponse> getPlaceReviews(int placeId) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<PlaceReviewListResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/place/review/${placeId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late PlaceReviewListResponse _value;
+    try {
+      _value = PlaceReviewListResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<PlaceRecommendResponse> recommendPlaceRaw(int placeId) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<PlaceRecommendResponse>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/place/recommend/${placeId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late PlaceRecommendResponse _value;
+    try {
+      _value = PlaceRecommendResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<PlaceRecommendResponse> unRecommendPlaceRaw(int placeId) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<PlaceRecommendResponse>(
+      Options(method: 'DELETE', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/place/recommend/${placeId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late PlaceRecommendResponse _value;
+    try {
+      _value = PlaceRecommendResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<void> createReviewRaw(int placeId, Map<String, dynamic> body) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body);
+    final _options = _setStreamType<void>(
+      Options(method: 'POST', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/review/${placeId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
+  }
+
+  @override
+  Future<MyReviewListResponse> getMyReviews() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<MyReviewListResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/review/me',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late MyReviewListResponse _value;
+    try {
+      _value = MyReviewListResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<MyReviewCountResponse> getMyReviewCountRaw() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<MyReviewCountResponse>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/review/count',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late MyReviewCountResponse _value;
+    try {
+      _value = MyReviewCountResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<void> deleteReview(int reviewId) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<void>(
+      Options(method: 'DELETE', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/review/${reviewId}',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}
+
+// dart format on

--- a/lib/features/map/data/repositories/recommended_place_repository_impl.dart
+++ b/lib/features/map/data/repositories/recommended_place_repository_impl.dart
@@ -1,4 +1,5 @@
 import 'package:goms/features/map/data/datasources/recommended_place_remote_datasource.dart';
+import 'package:goms/features/map/domain/entities/my_review_entity.dart';
 import 'package:goms/features/map/domain/entities/place_review_entity.dart';
 import 'package:goms/features/map/domain/entities/recommended_place_entity.dart';
 import 'package:goms/features/map/domain/repositories/recommended_place_repository.dart';
@@ -68,5 +69,21 @@ class RecommendedPlaceRepositoryImpl implements RecommendedPlaceRepository {
       placeId: placeId,
       content: content,
     );
+  }
+
+  @override
+  Future<List<MyReviewEntity>> getMyReviews() async {
+    final response = await _remoteDataSource.getMyReviews();
+    return response.toEntity();
+  }
+
+  @override
+  Future<int> getMyReviewCount() {
+    return _remoteDataSource.getMyReviewCount();
+  }
+
+  @override
+  Future<void> deleteReview(int reviewId) {
+    return _remoteDataSource.deleteReview(reviewId);
   }
 }

--- a/lib/features/map/data/response/my_review_count_response.dart
+++ b/lib/features/map/data/response/my_review_count_response.dart
@@ -1,0 +1,18 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'my_review_count_response.g.dart';
+
+@JsonSerializable(createToJson: false)
+class MyReviewCountResponse {
+  const MyReviewCountResponse({
+    required this.count,
+  });
+
+  factory MyReviewCountResponse.fromJson(Map<String, dynamic> json) =>
+      _$MyReviewCountResponseFromJson(json);
+
+  @JsonKey(defaultValue: 0, fromJson: _toInt)
+  final int count;
+}
+
+int _toInt(num? value) => value?.toInt() ?? 0;

--- a/lib/features/map/data/response/my_review_count_response.g.dart
+++ b/lib/features/map/data/response/my_review_count_response.g.dart
@@ -1,0 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'my_review_count_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+MyReviewCountResponse _$MyReviewCountResponseFromJson(
+        Map<String, dynamic> json) =>
+    MyReviewCountResponse(
+      count: json['count'] == null ? 0 : _toInt(json['count'] as num?),
+    );

--- a/lib/features/map/data/response/my_review_list_response.dart
+++ b/lib/features/map/data/response/my_review_list_response.dart
@@ -1,0 +1,25 @@
+import 'package:goms/features/map/data/response/my_review_response.dart';
+import 'package:goms/features/map/domain/entities/my_review_entity.dart';
+
+class MyReviewListResponse {
+  const MyReviewListResponse({
+    required this.reviews,
+  });
+
+  factory MyReviewListResponse.fromJson(Map<String, dynamic> json) {
+    final values = json['reviews'] as List<dynamic>? ?? const <dynamic>[];
+
+    return MyReviewListResponse(
+      reviews: values
+          .whereType<Map<String, dynamic>>()
+          .map(MyReviewResponse.fromJson)
+          .toList(growable: false),
+    );
+  }
+
+  final List<MyReviewResponse> reviews;
+
+  List<MyReviewEntity> toEntity() {
+    return reviews.map((review) => review.toEntity()).toList(growable: false);
+  }
+}

--- a/lib/features/map/data/response/my_review_response.dart
+++ b/lib/features/map/data/response/my_review_response.dart
@@ -1,0 +1,85 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:goms/features/map/domain/entities/my_review_entity.dart';
+
+part 'my_review_response.freezed.dart';
+part 'my_review_response.g.dart';
+
+@Freezed(fromJson: true, toJson: false)
+abstract class MyReviewResponse with _$MyReviewResponse {
+  const MyReviewResponse._();
+
+  const factory MyReviewResponse({
+    required int reviewId,
+    required int placeId,
+    required String placeName,
+    required String categoryName,
+    required String address,
+    required String content,
+    required DateTime? reviewedAt,
+  }) = _MyReviewResponse;
+
+  factory MyReviewResponse.fromJson(Map<String, dynamic> json) {
+    return _$MyReviewResponseFromJson(
+      <String, dynamic>{
+        ...json,
+        'reviewId': _toInt(json['reviewId']),
+        'placeId': _toInt(json['placeId']),
+        'placeName': _toString(json['placeName']),
+        'categoryName': _toString(json['categoryName']),
+        'address': _toString(json['address']),
+        'content': _toString(json['content']),
+        'reviewedAt': _toDateTimeString(json['reviewedAt']),
+      },
+    );
+  }
+
+  MyReviewEntity toEntity() {
+    return MyReviewEntity(
+      reviewId: reviewId,
+      placeId: placeId,
+      placeName: placeName,
+      categoryName: categoryName,
+      address: address,
+      content: content,
+      reviewedAt: _normalizeDateTime(reviewedAt),
+    );
+  }
+}
+
+int _toInt(Object? value) {
+  if (value is int) {
+    return value;
+  }
+  if (value is num) {
+    return value.toInt();
+  }
+  return int.tryParse('$value') ?? 0;
+}
+
+String _toString(Object? value) => value as String? ?? '';
+
+DateTime? _toNullableDateTime(Object? value) {
+  final raw = value as String?;
+  if (raw == null || raw.isEmpty) {
+    return null;
+  }
+
+  final parsed = DateTime.tryParse(raw);
+  if (parsed == null) {
+    return null;
+  }
+
+  return parsed.isUtc ? parsed.toLocal() : parsed;
+}
+
+String? _toDateTimeString(Object? value) {
+  final parsed = _toNullableDateTime(value);
+  return parsed?.toIso8601String();
+}
+
+DateTime? _normalizeDateTime(DateTime? value) {
+  if (value == null) {
+    return null;
+  }
+  return value.isUtc ? value.toLocal() : value;
+}

--- a/lib/features/map/data/response/my_review_response.freezed.dart
+++ b/lib/features/map/data/response/my_review_response.freezed.dart
@@ -1,0 +1,455 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'my_review_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$MyReviewResponse {
+  int get reviewId;
+  int get placeId;
+  String get placeName;
+  String get categoryName;
+  String get address;
+  String get content;
+  DateTime? get reviewedAt;
+
+  /// Create a copy of MyReviewResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $MyReviewResponseCopyWith<MyReviewResponse> get copyWith =>
+      _$MyReviewResponseCopyWithImpl<MyReviewResponse>(
+          this as MyReviewResponse, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is MyReviewResponse &&
+            (identical(other.reviewId, reviewId) ||
+                other.reviewId == reviewId) &&
+            (identical(other.placeId, placeId) || other.placeId == placeId) &&
+            (identical(other.placeName, placeName) ||
+                other.placeName == placeName) &&
+            (identical(other.categoryName, categoryName) ||
+                other.categoryName == categoryName) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.reviewedAt, reviewedAt) ||
+                other.reviewedAt == reviewedAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, reviewId, placeId, placeName,
+      categoryName, address, content, reviewedAt);
+
+  @override
+  String toString() {
+    return 'MyReviewResponse(reviewId: $reviewId, placeId: $placeId, placeName: $placeName, categoryName: $categoryName, address: $address, content: $content, reviewedAt: $reviewedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $MyReviewResponseCopyWith<$Res> {
+  factory $MyReviewResponseCopyWith(
+          MyReviewResponse value, $Res Function(MyReviewResponse) _then) =
+      _$MyReviewResponseCopyWithImpl;
+  @useResult
+  $Res call(
+      {int reviewId,
+      int placeId,
+      String placeName,
+      String categoryName,
+      String address,
+      String content,
+      DateTime? reviewedAt});
+}
+
+/// @nodoc
+class _$MyReviewResponseCopyWithImpl<$Res>
+    implements $MyReviewResponseCopyWith<$Res> {
+  _$MyReviewResponseCopyWithImpl(this._self, this._then);
+
+  final MyReviewResponse _self;
+  final $Res Function(MyReviewResponse) _then;
+
+  /// Create a copy of MyReviewResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? reviewId = null,
+    Object? placeId = null,
+    Object? placeName = null,
+    Object? categoryName = null,
+    Object? address = null,
+    Object? content = null,
+    Object? reviewedAt = freezed,
+  }) {
+    return _then(_self.copyWith(
+      reviewId: null == reviewId
+          ? _self.reviewId
+          : reviewId // ignore: cast_nullable_to_non_nullable
+              as int,
+      placeId: null == placeId
+          ? _self.placeId
+          : placeId // ignore: cast_nullable_to_non_nullable
+              as int,
+      placeName: null == placeName
+          ? _self.placeName
+          : placeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      categoryName: null == categoryName
+          ? _self.categoryName
+          : categoryName // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: null == address
+          ? _self.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      reviewedAt: freezed == reviewedAt
+          ? _self.reviewedAt
+          : reviewedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [MyReviewResponse].
+extension MyReviewResponsePatterns on MyReviewResponse {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_MyReviewResponse value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _MyReviewResponse() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_MyReviewResponse value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MyReviewResponse():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_MyReviewResponse value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MyReviewResponse() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            int reviewId,
+            int placeId,
+            String placeName,
+            String categoryName,
+            String address,
+            String content,
+            DateTime? reviewedAt)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _MyReviewResponse() when $default != null:
+        return $default(_that.reviewId, _that.placeId, _that.placeName,
+            _that.categoryName, _that.address, _that.content, _that.reviewedAt);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            int reviewId,
+            int placeId,
+            String placeName,
+            String categoryName,
+            String address,
+            String content,
+            DateTime? reviewedAt)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MyReviewResponse():
+        return $default(_that.reviewId, _that.placeId, _that.placeName,
+            _that.categoryName, _that.address, _that.content, _that.reviewedAt);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            int reviewId,
+            int placeId,
+            String placeName,
+            String categoryName,
+            String address,
+            String content,
+            DateTime? reviewedAt)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _MyReviewResponse() when $default != null:
+        return $default(_that.reviewId, _that.placeId, _that.placeName,
+            _that.categoryName, _that.address, _that.content, _that.reviewedAt);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+class _MyReviewResponse extends MyReviewResponse {
+  const _MyReviewResponse(
+      {required this.reviewId,
+      required this.placeId,
+      required this.placeName,
+      required this.categoryName,
+      required this.address,
+      required this.content,
+      required this.reviewedAt})
+      : super._();
+  factory _MyReviewResponse.fromJson(Map<String, dynamic> json) =>
+      _$MyReviewResponseFromJson(json);
+
+  @override
+  final int reviewId;
+  @override
+  final int placeId;
+  @override
+  final String placeName;
+  @override
+  final String categoryName;
+  @override
+  final String address;
+  @override
+  final String content;
+  @override
+  final DateTime? reviewedAt;
+
+  /// Create a copy of MyReviewResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$MyReviewResponseCopyWith<_MyReviewResponse> get copyWith =>
+      __$MyReviewResponseCopyWithImpl<_MyReviewResponse>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _MyReviewResponse &&
+            (identical(other.reviewId, reviewId) ||
+                other.reviewId == reviewId) &&
+            (identical(other.placeId, placeId) || other.placeId == placeId) &&
+            (identical(other.placeName, placeName) ||
+                other.placeName == placeName) &&
+            (identical(other.categoryName, categoryName) ||
+                other.categoryName == categoryName) &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.content, content) || other.content == content) &&
+            (identical(other.reviewedAt, reviewedAt) ||
+                other.reviewedAt == reviewedAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, reviewId, placeId, placeName,
+      categoryName, address, content, reviewedAt);
+
+  @override
+  String toString() {
+    return 'MyReviewResponse(reviewId: $reviewId, placeId: $placeId, placeName: $placeName, categoryName: $categoryName, address: $address, content: $content, reviewedAt: $reviewedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$MyReviewResponseCopyWith<$Res>
+    implements $MyReviewResponseCopyWith<$Res> {
+  factory _$MyReviewResponseCopyWith(
+          _MyReviewResponse value, $Res Function(_MyReviewResponse) _then) =
+      __$MyReviewResponseCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int reviewId,
+      int placeId,
+      String placeName,
+      String categoryName,
+      String address,
+      String content,
+      DateTime? reviewedAt});
+}
+
+/// @nodoc
+class __$MyReviewResponseCopyWithImpl<$Res>
+    implements _$MyReviewResponseCopyWith<$Res> {
+  __$MyReviewResponseCopyWithImpl(this._self, this._then);
+
+  final _MyReviewResponse _self;
+  final $Res Function(_MyReviewResponse) _then;
+
+  /// Create a copy of MyReviewResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? reviewId = null,
+    Object? placeId = null,
+    Object? placeName = null,
+    Object? categoryName = null,
+    Object? address = null,
+    Object? content = null,
+    Object? reviewedAt = freezed,
+  }) {
+    return _then(_MyReviewResponse(
+      reviewId: null == reviewId
+          ? _self.reviewId
+          : reviewId // ignore: cast_nullable_to_non_nullable
+              as int,
+      placeId: null == placeId
+          ? _self.placeId
+          : placeId // ignore: cast_nullable_to_non_nullable
+              as int,
+      placeName: null == placeName
+          ? _self.placeName
+          : placeName // ignore: cast_nullable_to_non_nullable
+              as String,
+      categoryName: null == categoryName
+          ? _self.categoryName
+          : categoryName // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: null == address
+          ? _self.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+      content: null == content
+          ? _self.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      reviewedAt: freezed == reviewedAt
+          ? _self.reviewedAt
+          : reviewedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/features/map/data/response/my_review_response.g.dart
+++ b/lib/features/map/data/response/my_review_response.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'my_review_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_MyReviewResponse _$MyReviewResponseFromJson(Map<String, dynamic> json) =>
+    _MyReviewResponse(
+      reviewId: (json['reviewId'] as num).toInt(),
+      placeId: (json['placeId'] as num).toInt(),
+      placeName: json['placeName'] as String,
+      categoryName: json['categoryName'] as String,
+      address: json['address'] as String,
+      content: json['content'] as String,
+      reviewedAt: json['reviewedAt'] == null
+          ? null
+          : DateTime.parse(json['reviewedAt'] as String),
+    );

--- a/lib/features/map/data/response/place_recommend_response.dart
+++ b/lib/features/map/data/response/place_recommend_response.dart
@@ -1,0 +1,16 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'place_recommend_response.g.dart';
+
+@JsonSerializable(createToJson: false)
+class PlaceRecommendResponse {
+  const PlaceRecommendResponse({
+    required this.recommended,
+  });
+
+  factory PlaceRecommendResponse.fromJson(Map<String, dynamic> json) =>
+      _$PlaceRecommendResponseFromJson(json);
+
+  @JsonKey(defaultValue: false)
+  final bool recommended;
+}

--- a/lib/features/map/data/response/place_recommend_response.g.dart
+++ b/lib/features/map/data/response/place_recommend_response.g.dart
@@ -1,0 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'place_recommend_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PlaceRecommendResponse _$PlaceRecommendResponseFromJson(
+        Map<String, dynamic> json) =>
+    PlaceRecommendResponse(
+      recommended: json['recommended'] as bool? ?? false,
+    );

--- a/lib/features/map/data/response/recommended_place_count_response.dart
+++ b/lib/features/map/data/response/recommended_place_count_response.dart
@@ -1,0 +1,18 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'recommended_place_count_response.g.dart';
+
+@JsonSerializable(createToJson: false)
+class RecommendedPlaceCountResponse {
+  const RecommendedPlaceCountResponse({
+    required this.recommendCount,
+  });
+
+  factory RecommendedPlaceCountResponse.fromJson(Map<String, dynamic> json) =>
+      _$RecommendedPlaceCountResponseFromJson(json);
+
+  @JsonKey(defaultValue: 0, fromJson: _toInt)
+  final int recommendCount;
+}
+
+int _toInt(num? value) => value?.toInt() ?? 0;

--- a/lib/features/map/data/response/recommended_place_count_response.g.dart
+++ b/lib/features/map/data/response/recommended_place_count_response.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recommended_place_count_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+RecommendedPlaceCountResponse _$RecommendedPlaceCountResponseFromJson(
+        Map<String, dynamic> json) =>
+    RecommendedPlaceCountResponse(
+      recommendCount: json['recommendCount'] == null
+          ? 0
+          : _toInt(json['recommendCount'] as num?),
+    );

--- a/lib/features/map/discovery/ui/models/map_screen_review_model.dart
+++ b/lib/features/map/discovery/ui/models/map_screen_review_model.dart
@@ -1,4 +1,5 @@
 class MapScreenReviewModel {
+  final int reviewId;
   final String placeName;
   final String category;
   final String address;
@@ -6,6 +7,7 @@ class MapScreenReviewModel {
   final DateTime createdAt;
 
   const MapScreenReviewModel({
+    required this.reviewId,
     required this.placeName,
     required this.category,
     required this.address,

--- a/lib/features/map/discovery/ui/providers/map_screen_provider.dart
+++ b/lib/features/map/discovery/ui/providers/map_screen_provider.dart
@@ -125,6 +125,37 @@ class MapScreenNotifier extends Notifier<MapScreenState> {
     }
   }
 
+  Future<void> deleteMyReview(int reviewId) async {
+    final currentReviews = state.reviewModels;
+    final nextReviews = currentReviews
+        .where((review) => review.reviewId != reviewId)
+        .toList(growable: false);
+    final removedCount = currentReviews.length - nextReviews.length;
+
+    if (removedCount == 0) {
+      return;
+    }
+
+    state = state.copyWith(
+      reviewModels: nextReviews,
+      reviewCount: max(0, state.reviewCount - removedCount),
+    );
+
+    try {
+      await ref.read(recommendedPlaceRepositoryProvider).deleteReview(reviewId);
+    } catch (error, stackTrace) {
+      if (ref.mounted) {
+        Logger.e(
+          'Delete my review request failed.',
+          tag: 'MAP',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+      rethrow;
+    }
+  }
+
   Future<List<PopularPlace>> _loadMarkerPlaces() async {
     try {
       final hotPlaces = await _loadHotPlaceEntities();
@@ -194,6 +225,7 @@ class MapScreenNotifier extends Notifier<MapScreenState> {
 
   MapScreenReviewModel _toMapScreenReviewModel(MyReviewEntity review) {
     return MapScreenReviewModel(
+      reviewId: review.reviewId,
       placeName: review.placeName,
       category: review.categoryName,
       address: review.address,

--- a/lib/features/map/discovery/ui/providers/map_screen_provider.dart
+++ b/lib/features/map/discovery/ui/providers/map_screen_provider.dart
@@ -7,6 +7,7 @@ import 'package:goms/features/map/data/providers/recommended_place_providers.dar
 import 'package:goms/features/map/discovery/ui/models/map_screen_review_model.dart';
 import 'package:goms/features/map/discovery/ui/models/map_screen_state.dart';
 import 'package:goms/features/map/discovery/ui/models/popular_place.dart';
+import 'package:goms/features/map/domain/entities/my_review_entity.dart';
 import 'package:goms/features/map/domain/entities/recommended_place_entity.dart';
 
 final mapScreenProvider = NotifierProvider<MapScreenNotifier, MapScreenState>(
@@ -33,6 +34,14 @@ class MapScreenNotifier extends Notifier<MapScreenState> {
 
     try {
       final popularPlaces = await _loadMarkerPlaces();
+      final myReviewModels = await _loadMyReviewModels();
+      final myReviewCount = await _loadMyReviewCount(
+        fallbackCount: myReviewModels.length,
+      );
+      final normalizedMyReviewModels = _normalizeMyReviewModels(
+        myReviewModels,
+        myReviewCount,
+      );
       if (!ref.mounted) {
         return;
       }
@@ -40,9 +49,8 @@ class MapScreenNotifier extends Notifier<MapScreenState> {
       state = state.copyWith(
         status: MapScreenStatus.success,
         popularPlaces: popularPlaces,
-        reviewModels: const <MapScreenReviewModel>[],
-        recommendedCount: 0,
-        reviewCount: 0,
+        reviewModels: normalizedMyReviewModels,
+        reviewCount: myReviewCount,
       );
     } catch (error, stackTrace) {
       if (!ref.mounted) {
@@ -146,6 +154,73 @@ class MapScreenNotifier extends Notifier<MapScreenState> {
     return ref
         .read(recommendedPlaceRepositoryProvider)
         .getHotPlaces(days: _hotPlaceDays);
+  }
+
+  Future<List<MapScreenReviewModel>> _loadMyReviewModels() async {
+    try {
+      final reviews =
+          await ref.read(recommendedPlaceRepositoryProvider).getMyReviews();
+      return reviews.map(_toMapScreenReviewModel).toList(growable: false);
+    } catch (error, stackTrace) {
+      if (ref.mounted) {
+        Logger.e(
+          'My review list request failed. Falling back to empty list.',
+          tag: 'MAP',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+      return const <MapScreenReviewModel>[];
+    }
+  }
+
+  Future<int> _loadMyReviewCount({required int fallbackCount}) async {
+    try {
+      return await ref
+          .read(recommendedPlaceRepositoryProvider)
+          .getMyReviewCount();
+    } catch (error, stackTrace) {
+      if (ref.mounted) {
+        Logger.e(
+          'My review count request failed. Falling back to list length.',
+          tag: 'MAP',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+      return fallbackCount;
+    }
+  }
+
+  MapScreenReviewModel _toMapScreenReviewModel(MyReviewEntity review) {
+    return MapScreenReviewModel(
+      placeName: review.placeName,
+      category: review.categoryName,
+      address: review.address,
+      reviewDetailContent: review.content,
+      createdAt: review.reviewedAt ?? DateTime.now(),
+    );
+  }
+
+  List<MapScreenReviewModel> _normalizeMyReviewModels(
+    List<MapScreenReviewModel> reviews,
+    int reviewCount,
+  ) {
+    if (reviewCount < 0) {
+      return const <MapScreenReviewModel>[];
+    }
+
+    if (reviews.length <= reviewCount) {
+      return reviews;
+    }
+
+    Logger.e(
+      'My review list size (${reviews.length}) exceeded my review count ($reviewCount). '
+      'Trimming list for safety.',
+      tag: 'MAP',
+    );
+
+    return reviews.take(reviewCount).toList(growable: false);
   }
 
   PopularPlace _toPopularPlace(RecommendedPlaceEntity place) {

--- a/lib/features/map/discovery/ui/providers/map_screen_provider.dart
+++ b/lib/features/map/discovery/ui/providers/map_screen_provider.dart
@@ -33,11 +33,14 @@ class MapScreenNotifier extends Notifier<MapScreenState> {
     );
 
     try {
-      final popularPlaces = await _loadMarkerPlaces();
-      final myReviewModels = await _loadMyReviewModels();
-      final myReviewCount = await _loadMyReviewCount(
-        fallbackCount: myReviewModels.length,
-      );
+      final results = await Future.wait<Object?>([
+        _loadMarkerPlaces(),
+        _loadMyReviewModels(),
+        _loadMyReviewCountOrNull(),
+      ]);
+      final popularPlaces = results[0]! as List<PopularPlace>;
+      final myReviewModels = results[1]! as List<MapScreenReviewModel>;
+      final myReviewCount = (results[2] as int?) ?? myReviewModels.length;
       final normalizedMyReviewModels = _normalizeMyReviewModels(
         myReviewModels,
         myReviewCount,
@@ -205,7 +208,7 @@ class MapScreenNotifier extends Notifier<MapScreenState> {
     }
   }
 
-  Future<int> _loadMyReviewCount({required int fallbackCount}) async {
+  Future<int?> _loadMyReviewCountOrNull() async {
     try {
       return await ref
           .read(recommendedPlaceRepositoryProvider)
@@ -213,13 +216,13 @@ class MapScreenNotifier extends Notifier<MapScreenState> {
     } catch (error, stackTrace) {
       if (ref.mounted) {
         Logger.e(
-          'My review count request failed. Falling back to list length.',
+          'My review count request failed. Falling back to loaded review list length.',
           tag: 'MAP',
           error: error,
           stackTrace: stackTrace,
         );
       }
-      return fallbackCount;
+      return null;
     }
   }
 

--- a/lib/features/map/discovery/ui/providers/map_screen_provider.dart
+++ b/lib/features/map/discovery/ui/providers/map_screen_provider.dart
@@ -130,6 +130,7 @@ class MapScreenNotifier extends Notifier<MapScreenState> {
 
   Future<void> deleteMyReview(int reviewId) async {
     final currentReviews = state.reviewModels;
+    final previousReviewCount = state.reviewCount;
     final nextReviews = currentReviews
         .where((review) => review.reviewId != reviewId)
         .toList(growable: false);
@@ -153,6 +154,10 @@ class MapScreenNotifier extends Notifier<MapScreenState> {
           tag: 'MAP',
           error: error,
           stackTrace: stackTrace,
+        );
+        state = state.copyWith(
+          reviewModels: currentReviews,
+          reviewCount: previousReviewCount,
         );
       }
       rethrow;

--- a/lib/features/map/domain/entities/my_review_entity.dart
+++ b/lib/features/map/domain/entities/my_review_entity.dart
@@ -1,0 +1,19 @@
+class MyReviewEntity {
+  const MyReviewEntity({
+    required this.reviewId,
+    required this.placeId,
+    required this.placeName,
+    required this.categoryName,
+    required this.address,
+    required this.content,
+    required this.reviewedAt,
+  });
+
+  final int reviewId;
+  final int placeId;
+  final String placeName;
+  final String categoryName;
+  final String address;
+  final String content;
+  final DateTime? reviewedAt;
+}

--- a/lib/features/map/domain/repositories/recommended_place_repository.dart
+++ b/lib/features/map/domain/repositories/recommended_place_repository.dart
@@ -1,3 +1,4 @@
+import 'package:goms/features/map/domain/entities/my_review_entity.dart';
 import 'package:goms/features/map/domain/entities/place_review_entity.dart';
 import 'package:goms/features/map/domain/entities/recommended_place_entity.dart';
 
@@ -15,4 +16,7 @@ abstract class RecommendedPlaceRepository {
     required int placeId,
     required String content,
   });
+  Future<List<MyReviewEntity>> getMyReviews();
+  Future<int> getMyReviewCount();
+  Future<void> deleteReview(int reviewId);
 }

--- a/lib/features/map/review/ui/screens/review_list_screen.dart
+++ b/lib/features/map/review/ui/screens/review_list_screen.dart
@@ -15,7 +15,8 @@ import 'package:goms/core/widgets/scaffolds/base_scaffold.dart';
 import 'package:goms/core/widgets/text_fields/search_text_field.dart';
 
 final myReviewIdsProvider = FutureProvider<Set<int>>((ref) async {
-  final myReviews = await ref.read(recommendedPlaceRepositoryProvider).getMyReviews();
+  final myReviews =
+      await ref.read(recommendedPlaceRepositoryProvider).getMyReviews();
   return myReviews.map((review) => review.reviewId).toSet();
 });
 
@@ -79,14 +80,14 @@ class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
     final placeReviewsAsync = ref.watch(placeReviewsProvider(widget.placeId));
     final myReviewIdsAsync = ref.watch(myReviewIdsProvider);
     final placeReviews =
-      placeReviewsAsync.asData?.value ?? const <PlaceReviewEntity>[];
+        placeReviewsAsync.asData?.value ?? const <PlaceReviewEntity>[];
     final myReviewIds = myReviewIdsAsync.asData?.value ?? const <int>{};
     final reviews = placeReviews
-      .where((review) => !_deletedReviewIds.contains(review.reviewId))
-      .toList(growable: false);
+        .where((review) => !_deletedReviewIds.contains(review.reviewId))
+        .toList(growable: false);
     final reviewCount = reviews.length;
     final isReviewLoading =
-      placeReviewsAsync.isLoading && placeReviewsAsync.asData == null;
+        placeReviewsAsync.isLoading && placeReviewsAsync.asData == null;
     final isReviewLoadFailed = placeReviewsAsync.hasError;
 
     return BaseScaffold(
@@ -402,7 +403,8 @@ class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
                                           Column(
                                             children: reviews
                                                 .map(
-                                                  (review) => ReviewListContainer(
+                                                  (review) =>
+                                                      ReviewListContainer(
                                                     reviewId: review.reviewId,
                                                     name: review.name,
                                                     grade: review.grade,
@@ -412,8 +414,8 @@ class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
                                                     createdAt:
                                                         review.reviewedAt ??
                                                             DateTime.now(),
-                                                    isMine: myReviewIds
-                                                        .contains(
+                                                    isMine:
+                                                        myReviewIds.contains(
                                                             review.reviewId),
                                                     onDelete: _deleteReview,
                                                   ),

--- a/lib/features/map/review/ui/screens/review_list_screen.dart
+++ b/lib/features/map/review/ui/screens/review_list_screen.dart
@@ -6,6 +6,7 @@ import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
 import 'package:goms/core/theme/typography/app_text_styles.dart';
 import 'package:goms/core/utils/logger.dart';
+import 'package:goms/features/map/domain/entities/place_review_entity.dart';
 import 'package:goms/features/map/shared/ui/widgets/arrival_departure_button.dart';
 import 'package:goms/features/map/shared/ui/widgets/drag_handle_header.dart';
 import 'package:goms/features/map/shared/ui/widgets/review_list_container.dart';
@@ -13,7 +14,13 @@ import 'package:goms/features/map/data/providers/recommended_place_providers.dar
 import 'package:goms/core/widgets/scaffolds/base_scaffold.dart';
 import 'package:goms/core/widgets/text_fields/search_text_field.dart';
 
+final myReviewIdsProvider = FutureProvider<Set<int>>((ref) async {
+  final myReviews = await ref.read(recommendedPlaceRepositoryProvider).getMyReviews();
+  return myReviews.map((review) => review.reviewId).toSet();
+});
+
 class ReviewListScreen extends ConsumerStatefulWidget {
+  final int placeId;
   final String placeName;
   final String category;
   final String address;
@@ -24,6 +31,7 @@ class ReviewListScreen extends ConsumerStatefulWidget {
 
   const ReviewListScreen({
     super.key,
+    required this.placeId,
     required this.placeName,
     required this.category,
     required this.address,
@@ -40,45 +48,15 @@ class ReviewListScreen extends ConsumerStatefulWidget {
 class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
   final DraggableScrollableController sheetController =
       DraggableScrollableController();
-  late final List<_ReviewListItem> _reviews;
-
-  @override
-  void initState() {
-    super.initState();
-    _reviews = <_ReviewListItem>[
-      _ReviewListItem(
-        reviewId: 1,
-        name: '류수연',
-        grade: 9,
-        major: 'SW개발',
-        content: '굳굳',
-        createdAt: DateTime.now(),
-        isMine: true,
-      ),
-      _ReviewListItem(
-        reviewId: 2,
-        name: '류수연',
-        grade: 9,
-        major: 'SW개발',
-        content: '굳굳',
-        createdAt: DateTime.now(),
-        isMine: true,
-      ),
-      _ReviewListItem(
-        reviewId: 3,
-        name: '류수연',
-        grade: 9,
-        major: 'SW개발',
-        content: '굳굳',
-        createdAt: DateTime.now(),
-        isMine: false,
-      ),
-    ];
-  }
+  final Set<int> _deletedReviewIds = <int>{};
 
   Future<void> _deleteReview(int reviewId) async {
+    if (_deletedReviewIds.contains(reviewId)) {
+      return;
+    }
+
     setState(() {
-      _reviews.removeWhere((review) => review.reviewId == reviewId);
+      _deletedReviewIds.add(reviewId);
     });
 
     try {
@@ -98,7 +76,19 @@ class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
   Widget build(BuildContext context) {
     final isLight = context.isLightMode;
     final horizontalPadding = context.horizontalPadding;
-    final reviewCount = _reviews.length;
+    final placeReviewsAsync = ref.watch(placeReviewsProvider(widget.placeId));
+    final myReviewIdsAsync = ref.watch(myReviewIdsProvider);
+    final placeReviews =
+      placeReviewsAsync.asData?.value ?? const <PlaceReviewEntity>[];
+    final myReviewIds = myReviewIdsAsync.asData?.value ?? const <int>{};
+    final reviews = placeReviews
+      .where((review) => !_deletedReviewIds.contains(review.reviewId))
+      .toList(growable: false);
+    final reviewCount = reviews.length;
+    final isReviewLoading =
+      placeReviewsAsync.isLoading && placeReviewsAsync.asData == null;
+    final isReviewLoadFailed = placeReviewsAsync.hasError;
+
     return BaseScaffold(
       showAppBar: false,
       contentPadding: EdgeInsets.zero,
@@ -387,12 +377,20 @@ class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
                                             ),
                                           ],
                                         ),
-                                        if (_reviews.isEmpty) ...[
+                                        if (isReviewLoading) ...[
+                                          AppGap.v20,
+                                          const Center(
+                                            child: CircularProgressIndicator(),
+                                          ),
+                                          AppGap.v20,
+                                        ] else if (reviews.isEmpty) ...[
                                           AppGap.v12,
                                           AppIcons.coffee(),
                                           AppGap.v12,
                                           Text(
-                                            '아직 후기가 없어요!\n첫 후기를 작성해봐요!',
+                                            isReviewLoadFailed
+                                                ? '후기를 불러오지 못했어요.\n잠시 후 다시 시도해 주세요.'
+                                                : '아직 후기가 없어요!\n첫 후기를 작성해봐요!',
                                             style:
                                                 AppTextStyles.caption1.copyWith(
                                               color: AppColors.sub2,
@@ -402,17 +400,21 @@ class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
                                           AppGap.v20,
                                         ] else ...[
                                           Column(
-                                            children: _reviews
+                                            children: reviews
                                                 .map(
                                                   (review) => ReviewListContainer(
                                                     reviewId: review.reviewId,
                                                     name: review.name,
                                                     grade: review.grade,
-                                                    major: review.major,
+                                                    major: review.department,
                                                     reviewDetailContent:
                                                         review.content,
-                                                    createdAt: review.createdAt,
-                                                    isMine: review.isMine,
+                                                    createdAt:
+                                                        review.reviewedAt ??
+                                                            DateTime.now(),
+                                                    isMine: myReviewIds
+                                                        .contains(
+                                                            review.reviewId),
                                                     onDelete: _deleteReview,
                                                   ),
                                                 )
@@ -438,24 +440,4 @@ class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
       ),
     );
   }
-}
-
-class _ReviewListItem {
-  const _ReviewListItem({
-    required this.reviewId,
-    required this.name,
-    required this.grade,
-    required this.major,
-    required this.content,
-    required this.createdAt,
-    required this.isMine,
-  });
-
-  final int reviewId;
-  final String name;
-  final int grade;
-  final String major;
-  final String content;
-  final DateTime createdAt;
-  final bool isMine;
 }

--- a/lib/features/map/review/ui/screens/review_list_screen.dart
+++ b/lib/features/map/review/ui/screens/review_list_screen.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/icons/app_icons.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
 import 'package:goms/core/theme/typography/app_text_styles.dart';
+import 'package:goms/core/utils/logger.dart';
 import 'package:goms/features/map/shared/ui/widgets/arrival_departure_button.dart';
 import 'package:goms/features/map/shared/ui/widgets/drag_handle_header.dart';
 import 'package:goms/features/map/shared/ui/widgets/review_list_container.dart';
+import 'package:goms/features/map/data/providers/recommended_place_providers.dart';
 import 'package:goms/core/widgets/scaffolds/base_scaffold.dart';
 import 'package:goms/core/widgets/text_fields/search_text_field.dart';
 
-class ReviewListScreen extends StatefulWidget {
+class ReviewListScreen extends ConsumerStatefulWidget {
   final String placeName;
   final String category;
   final String address;
@@ -31,17 +34,71 @@ class ReviewListScreen extends StatefulWidget {
   });
 
   @override
-  State<ReviewListScreen> createState() => _ReviewListScreenState();
+  ConsumerState<ReviewListScreen> createState() => _ReviewListScreenState();
 }
 
-class _ReviewListScreenState extends State<ReviewListScreen> {
+class _ReviewListScreenState extends ConsumerState<ReviewListScreen> {
   final DraggableScrollableController sheetController =
       DraggableScrollableController();
+  late final List<_ReviewListItem> _reviews;
+
+  @override
+  void initState() {
+    super.initState();
+    _reviews = <_ReviewListItem>[
+      _ReviewListItem(
+        reviewId: 1,
+        name: '류수연',
+        grade: 9,
+        major: 'SW개발',
+        content: '굳굳',
+        createdAt: DateTime.now(),
+        isMine: true,
+      ),
+      _ReviewListItem(
+        reviewId: 2,
+        name: '류수연',
+        grade: 9,
+        major: 'SW개발',
+        content: '굳굳',
+        createdAt: DateTime.now(),
+        isMine: true,
+      ),
+      _ReviewListItem(
+        reviewId: 3,
+        name: '류수연',
+        grade: 9,
+        major: 'SW개발',
+        content: '굳굳',
+        createdAt: DateTime.now(),
+        isMine: false,
+      ),
+    ];
+  }
+
+  Future<void> _deleteReview(int reviewId) async {
+    setState(() {
+      _reviews.removeWhere((review) => review.reviewId == reviewId);
+    });
+
+    try {
+      await ref.read(recommendedPlaceRepositoryProvider).deleteReview(reviewId);
+    } catch (error, stackTrace) {
+      Logger.e(
+        'Review list delete request failed.',
+        tag: 'MAP',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      rethrow;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final isLight = context.isLightMode;
     final horizontalPadding = context.horizontalPadding;
+    final reviewCount = _reviews.length;
     return BaseScaffold(
       showAppBar: false,
       contentPadding: EdgeInsets.zero,
@@ -196,7 +253,7 @@ class _ReviewListScreenState extends State<ReviewListScreen> {
                                             ),
                                             AppGap.h4,
                                             Text(
-                                              '${widget.review}',
+                                              '$reviewCount',
                                               style:
                                                   AppTextStyles.text2.copyWith(
                                                 color: isLight
@@ -280,8 +337,7 @@ class _ReviewListScreenState extends State<ReviewListScreen> {
                                                   text: TextSpan(
                                                     children: [
                                                       TextSpan(
-                                                        text:
-                                                            '${widget.review}',
+                                                        text: '$reviewCount',
                                                         style: AppTextStyles
                                                             .text3
                                                             .copyWith(
@@ -331,7 +387,7 @@ class _ReviewListScreenState extends State<ReviewListScreen> {
                                             ),
                                           ],
                                         ),
-                                        if (widget.review == 0) ...[
+                                        if (_reviews.isEmpty) ...[
                                           AppGap.v12,
                                           AppIcons.coffee(),
                                           AppGap.v12,
@@ -346,32 +402,21 @@ class _ReviewListScreenState extends State<ReviewListScreen> {
                                           AppGap.v20,
                                         ] else ...[
                                           Column(
-                                            children: [
-                                              ReviewListContainer(
-                                                name: '류수연',
-                                                grade: 9,
-                                                major: 'SW개발',
-                                                reviewDetailContent: '굳굳',
-                                                createdAt: DateTime.now(),
-                                                isMine: true,
-                                              ),
-                                              ReviewListContainer(
-                                                name: '류수연',
-                                                grade: 9,
-                                                major: 'SW개발',
-                                                reviewDetailContent: '굳굳',
-                                                createdAt: DateTime.now(),
-                                                isMine: true,
-                                              ),
-                                              ReviewListContainer(
-                                                name: '류수연',
-                                                grade: 9,
-                                                major: 'SW개발',
-                                                reviewDetailContent: '굳굳',
-                                                createdAt: DateTime.now(),
-                                                isMine: false,
-                                              ),
-                                            ],
+                                            children: _reviews
+                                                .map(
+                                                  (review) => ReviewListContainer(
+                                                    reviewId: review.reviewId,
+                                                    name: review.name,
+                                                    grade: review.grade,
+                                                    major: review.major,
+                                                    reviewDetailContent:
+                                                        review.content,
+                                                    createdAt: review.createdAt,
+                                                    isMine: review.isMine,
+                                                    onDelete: _deleteReview,
+                                                  ),
+                                                )
+                                                .toList(growable: false),
                                           ),
                                         ],
                                       ],
@@ -393,4 +438,24 @@ class _ReviewListScreenState extends State<ReviewListScreen> {
       ),
     );
   }
+}
+
+class _ReviewListItem {
+  const _ReviewListItem({
+    required this.reviewId,
+    required this.name,
+    required this.grade,
+    required this.major,
+    required this.content,
+    required this.createdAt,
+    required this.isMine,
+  });
+
+  final int reviewId;
+  final String name;
+  final int grade;
+  final String major;
+  final String content;
+  final DateTime createdAt;
+  final bool isMine;
 }

--- a/lib/features/map/shared/ui/widgets/map_main_overlay.dart
+++ b/lib/features/map/shared/ui/widgets/map_main_overlay.dart
@@ -7,6 +7,7 @@ import 'package:goms/core/theme/icons/app_icons.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
 import 'package:goms/core/theme/typography/app_text_styles.dart';
+import 'package:goms/core/widgets/dialogs/goms_dialog.dart';
 import 'package:goms/core/widgets/text_fields/search_text_field.dart';
 import 'package:goms/features/map/data/map_constants.dart';
 import 'package:goms/features/map/data/providers/recommended_place_providers.dart';
@@ -358,6 +359,51 @@ class _MyActivitySection extends StatelessWidget {
     this.onPlaceTap,
   });
 
+  Future<void> _showDeleteReviewDialog({
+    required BuildContext context,
+    required WidgetRef ref,
+    required MapScreenReviewModel review,
+  }) {
+    return GomsDialog.confirm(
+      title: '후기 삭제',
+      content: '정말 후기를 삭제하시겠습니까?',
+      cancelText: '취소',
+      confirmText: '삭제',
+      isDestructive: true,
+      onConfirm: () => _deleteReview(
+        context: context,
+        ref: ref,
+        review: review,
+      ),
+    ).show(context);
+  }
+
+  void _deleteReview({
+    required BuildContext context,
+    required WidgetRef ref,
+    required MapScreenReviewModel review,
+  }) async {
+    try {
+      await ref
+          .read(mapScreenProvider.notifier)
+          .deleteMyReview(review.reviewId);
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('후기를 삭제했습니다.'),
+        ),
+      );
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('후기 삭제에 실패했습니다.'),
+          backgroundColor: AppColors.negative,
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer(
@@ -460,6 +506,11 @@ class _MyActivitySection extends StatelessWidget {
                     address: review.address,
                     reviewContent: review.reviewDetailContent,
                     reviewCreatedAt: review.createdAt,
+                    onActionPressed: () => _showDeleteReviewDialog(
+                      context: context,
+                      ref: ref,
+                      review: review,
+                    ),
                   ),
                 ),
               ),

--- a/lib/features/map/shared/ui/widgets/map_main_overlay.dart
+++ b/lib/features/map/shared/ui/widgets/map_main_overlay.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:intl/intl.dart';
 import 'package:goms/app/router/route_path.dart';
 import 'package:goms/core/theme/colors/app_colors.dart';
+import 'package:goms/core/theme/icons/app_icons.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
 import 'package:goms/core/theme/typography/app_text_styles.dart';
@@ -193,16 +193,16 @@ class _PopularPlacesSection extends StatelessWidget {
             Row(
               children: [
                 Text(
-                  isSearching ? '검색 결과' : '인기 장소',
+                  isSearching ? '검색 결과' : '최근 인기 장소',
                   style: AppTextStyles.title3.copyWith(
                     color: _mainTextColor(isLight),
                   ),
                 ),
-                AppGap.h4,
+                AppGap.h2,
                 if (!isSearching)
-                  const Icon(
-                    Icons.local_fire_department_rounded,
-                    size: 18,
+                  AppIcons.fire(
+                    width: 24,
+                    height: 24,
                     color: AppColors.negative,
                   ),
               ],
@@ -221,7 +221,7 @@ class _PopularPlacesSection extends StatelessWidget {
               ...popularPlaces.map(
                 (place) => Padding(
                   padding: const EdgeInsets.only(bottom: 12),
-                  child: PlaceContainer(
+                  child: PlaceContainer.popular(
                     placeName: place.name,
                     category: place.category,
                     address: place.address,
@@ -401,7 +401,7 @@ class _MyActivitySection extends StatelessWidget {
               ...recommendedPlaces.take(2).map(
                     (place) => Padding(
                       padding: const EdgeInsets.only(bottom: 12),
-                      child: PlaceContainer(
+                      child: PlaceContainer.popular(
                         placeName: place.name,
                         category: place.category,
                         address: place.address,
@@ -454,9 +454,12 @@ class _MyActivitySection extends StatelessWidget {
               ...reviewModels.map(
                 (review) => Padding(
                   padding: const EdgeInsets.only(bottom: 12),
-                  child: _ReviewCard(
-                    review: review,
-                    isLight: isLight,
+                  child: PlaceContainer.review(
+                    placeName: review.placeName,
+                    category: review.category,
+                    address: review.address,
+                    reviewContent: review.reviewDetailContent,
+                    reviewCreatedAt: review.createdAt,
                   ),
                 ),
               ),
@@ -473,75 +476,6 @@ PopularPlace _toPopularPlace(RecommendedPlaceEntity place) {
     place,
     fallbackCoordinate: gomsFallbackSchoolCoordinate,
   );
-}
-
-class _ReviewCard extends StatelessWidget {
-  final MapScreenReviewModel review;
-  final bool isLight;
-
-  const _ReviewCard({
-    required this.review,
-    required this.isLight,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(AppSpacing.s16),
-      decoration: BoxDecoration(
-        color:
-            isLight ? AppColors.bgMapContainer : AppColors.bgMapContainerDark,
-        borderRadius: BorderRadius.circular(16),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Flexible(
-                child: Text(
-                  review.placeName,
-                  style: AppTextStyles.text1.copyWith(
-                    color: _mainTextColor(isLight),
-                  ),
-                ),
-              ),
-              AppGap.h4,
-              Text(
-                review.category,
-                style: AppTextStyles.caption2.copyWith(
-                  color: _subTextColor(isLight),
-                ),
-              ),
-            ],
-          ),
-          AppGap.v4,
-          Text(
-            review.address,
-            style: AppTextStyles.caption1.copyWith(
-              color: _subTextColor(isLight),
-            ),
-          ),
-          AppGap.v12,
-          Text(
-            review.reviewDetailContent,
-            style: AppTextStyles.text3.copyWith(
-              color: _mainTextColor(isLight),
-            ),
-          ),
-          AppGap.v12,
-          Text(
-            DateFormat('yy.MM.dd').format(review.createdAt),
-            style: AppTextStyles.caption2.copyWith(
-              color: _subTextColor(isLight),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
 }
 
 class _ActivityCountRow extends StatelessWidget {

--- a/lib/features/map/shared/ui/widgets/place_container.dart
+++ b/lib/features/map/shared/ui/widgets/place_container.dart
@@ -4,8 +4,10 @@ import 'package:goms/core/theme/icons/app_icons.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
 import 'package:goms/core/theme/typography/app_text_styles.dart';
+import 'package:intl/intl.dart';
 
 class PlaceContainer extends StatelessWidget {
+  final _PlaceContainerVariant _variant;
   final String placeName;
   final String category;
   final String address;
@@ -13,11 +15,15 @@ class PlaceContainer extends StatelessWidget {
   final int recommended;
   final bool isLiked;
   final int? distanceMeters;
+  final String? reviewContent;
+  final DateTime? reviewCreatedAt;
   final VoidCallback? onTap;
   final VoidCallback? onLikePressed;
+  final VoidCallback? onActionPressed;
 
-  const PlaceContainer({
+  const PlaceContainer._({
     super.key,
+    required _PlaceContainerVariant variant,
     required this.placeName,
     required this.category,
     required this.address,
@@ -25,9 +31,65 @@ class PlaceContainer extends StatelessWidget {
     required this.recommended,
     required this.isLiked,
     this.distanceMeters,
+    this.reviewContent,
+    this.reviewCreatedAt,
     this.onTap,
     this.onLikePressed,
-  });
+    this.onActionPressed,
+  }) : _variant = variant;
+
+  factory PlaceContainer.popular({
+    Key? key,
+    required String placeName,
+    required String category,
+    required String address,
+    required int review,
+    required int recommended,
+    required bool isLiked,
+    int? distanceMeters,
+    VoidCallback? onTap,
+    VoidCallback? onLikePressed,
+  }) {
+    return PlaceContainer._(
+      key: key,
+      variant: _PlaceContainerVariant.popular,
+      placeName: placeName,
+      category: category,
+      address: address,
+      review: review,
+      recommended: recommended,
+      isLiked: isLiked,
+      distanceMeters: distanceMeters,
+      onTap: onTap,
+      onLikePressed: onLikePressed,
+    );
+  }
+
+  factory PlaceContainer.review({
+    Key? key,
+    required String placeName,
+    required String category,
+    required String address,
+    required String reviewContent,
+    required DateTime reviewCreatedAt,
+    VoidCallback? onTap,
+    VoidCallback? onActionPressed,
+  }) {
+    return PlaceContainer._(
+      key: key,
+      variant: _PlaceContainerVariant.review,
+      placeName: placeName,
+      category: category,
+      address: address,
+      review: 0,
+      recommended: 0,
+      isLiked: false,
+      reviewContent: reviewContent,
+      reviewCreatedAt: reviewCreatedAt,
+      onTap: onTap,
+      onActionPressed: onActionPressed,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -46,30 +108,47 @@ class PlaceContainer extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.s16),
           child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Expanded(
-                child: _PlaceContent(
-                  placeName: placeName,
-                  category: category,
-                  address: address,
-                  review: review,
-                  recommended: recommended,
-                  distanceMeters: distanceMeters,
-                  colors: colors,
+                child: _variant == _PlaceContainerVariant.popular
+                    ? _PlaceContent(
+                        placeName: placeName,
+                        category: category,
+                        address: address,
+                        review: review,
+                        recommended: recommended,
+                        distanceMeters: distanceMeters,
+                        isLiked: isLiked,
+                        onLikePressed: onLikePressed,
+                        colors: colors,
+                      )
+                    : _ReviewContent(
+                        placeName: placeName,
+                        category: category,
+                        address: address,
+                        reviewContent: reviewContent ?? '',
+                        reviewCreatedAt: reviewCreatedAt,
+                        colors: colors,
+                      ),
+              ),
+              if (_variant == _PlaceContainerVariant.review) ...[
+                AppGap.h8,
+                Center(
+                  child: _ReviewActionButton(onPressed: onActionPressed),
                 ),
-              ),
-              AppGap.h8,
-              _LikeButton(
-                isLiked: isLiked,
-                onPressed: onLikePressed,
-              ),
+              ],
             ],
           ),
         ),
       ),
     );
   }
+}
+
+enum _PlaceContainerVariant {
+  popular,
+  review,
 }
 
 class _PlaceContent extends StatelessWidget {
@@ -79,6 +158,8 @@ class _PlaceContent extends StatelessWidget {
   final int review;
   final int recommended;
   final int? distanceMeters;
+  final bool isLiked;
+  final VoidCallback? onLikePressed;
   final _PlaceContainerColors colors;
 
   const _PlaceContent({
@@ -88,6 +169,106 @@ class _PlaceContent extends StatelessWidget {
     required this.review,
     required this.recommended,
     required this.distanceMeters,
+    required this.isLiked,
+    required this.onLikePressed,
+    required this.colors,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _PlaceTitleRow(
+                placeName: placeName,
+                category: category,
+                colors: colors,
+              ),
+              AppGap.v4,
+              Text(
+                address,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: AppTextStyles.caption1.copyWith(color: colors.subColor),
+              ),
+              if (distanceMeters != null) ...[
+                AppGap.v4,
+                Text(
+                  '학교 기준 ${distanceMeters}m',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style:
+                      AppTextStyles.caption2.copyWith(color: colors.subColor),
+                ),
+              ],
+              AppGap.v4,
+              Wrap(
+                spacing: AppSpacing.s4,
+                runSpacing: AppSpacing.s2,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  Text(
+                    '학생 후기',
+                    style:
+                        AppTextStyles.caption1.copyWith(color: colors.subColor),
+                  ),
+                  Text(
+                    _formatCount(review),
+                    style:
+                        AppTextStyles.caption1.copyWith(color: colors.subColor),
+                  ),
+                  Text(
+                    '|',
+                    style:
+                        AppTextStyles.caption1.copyWith(color: colors.subColor),
+                  ),
+                  Text(
+                    '추천',
+                    style:
+                        AppTextStyles.caption1.copyWith(color: colors.subColor),
+                  ),
+                  Text(
+                    _formatCount(recommended),
+                    style:
+                        AppTextStyles.caption1.copyWith(color: colors.subColor),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        AppGap.h8,
+        _LikeButton(
+          isLiked: isLiked,
+          onPressed: onLikePressed,
+        ),
+      ],
+    );
+  }
+
+  String _formatCount(int value) {
+    return value >= 10 ? '$value+' : value.toString();
+  }
+}
+
+class _ReviewContent extends StatelessWidget {
+  final String placeName;
+  final String category;
+  final String address;
+  final String reviewContent;
+  final DateTime? reviewCreatedAt;
+  final _PlaceContainerColors colors;
+
+  const _ReviewContent({
+    required this.placeName,
+    required this.category,
+    required this.address,
+    required this.reviewContent,
+    required this.reviewCreatedAt,
     required this.colors,
   });
 
@@ -99,49 +280,31 @@ class _PlaceContent extends StatelessWidget {
       children: [
         _PlaceTitleRow(
           placeName: placeName,
-          category: category,
+          category: _formatReviewCategory(category),
           colors: colors,
         ),
         AppGap.v4,
         Text(
           address,
-          maxLines: 2,
+          maxLines: 1,
           overflow: TextOverflow.ellipsis,
           style: AppTextStyles.caption1.copyWith(color: colors.subColor),
         ),
-        if (distanceMeters != null) ...[
-          AppGap.v4,
-          Text(
-            '학교 기준 ${distanceMeters}m',
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: AppTextStyles.caption2.copyWith(color: colors.subColor),
-          ),
-        ],
-        AppGap.v8,
-        Wrap(
-          spacing: AppSpacing.s4,
-          runSpacing: AppSpacing.s2,
-          crossAxisAlignment: WrapCrossAlignment.center,
+        AppGap.v4,
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            Text(
-              '학생 후기',
-              style: AppTextStyles.caption1.copyWith(color: colors.subColor),
+            Expanded(
+              child: Text(
+                reviewContent,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTextStyles.caption1.copyWith(color: colors.subColor),
+              ),
             ),
+            AppGap.h4,
             Text(
-              _formatCount(review),
-              style: AppTextStyles.caption1.copyWith(color: colors.subColor),
-            ),
-            Text(
-              '|',
-              style: AppTextStyles.caption1.copyWith(color: colors.subColor),
-            ),
-            Text(
-              '추천',
-              style: AppTextStyles.caption1.copyWith(color: colors.subColor),
-            ),
-            Text(
-              _formatCount(recommended),
+              '작성일: ${_formatDate(reviewCreatedAt)}',
               style: AppTextStyles.caption1.copyWith(color: colors.subColor),
             ),
           ],
@@ -150,8 +313,29 @@ class _PlaceContent extends StatelessWidget {
     );
   }
 
-  String _formatCount(int value) {
-    return value >= 10 ? '$value+' : value.toString();
+  String _formatDate(DateTime? value) {
+    if (value == null) {
+      return '-';
+    }
+    return DateFormat('yy.MM.dd').format(value);
+  }
+
+  String _formatReviewCategory(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return '';
+    }
+
+    final segments = trimmed
+        .split(RegExp(r'\s*(?:->|→|>)\s*'))
+        .where((segment) => segment.trim().isNotEmpty)
+        .toList(growable: false);
+
+    if (segments.isEmpty) {
+      return trimmed;
+    }
+
+    return segments.last.trim();
   }
 }
 
@@ -169,29 +353,22 @@ class _PlaceTitleRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
-      crossAxisAlignment: CrossAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Expanded(
-          flex: 3,
-          child: Text(
-            placeName,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: AppTextStyles.text2.copyWith(color: colors.mainTextColor),
-          ),
+        Text(
+          placeName,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTextStyles.text2.copyWith(color: colors.mainTextColor),
         ),
         if (category.trim().isNotEmpty) ...[
           AppGap.h4,
-          Flexible(
-            flex: 2,
-            child: Text(
-              category,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.right,
-              style:
-                  AppTextStyles.caption1.copyWith(color: colors.categoryColor),
-            ),
+          Text(
+            category,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.right,
+            style: AppTextStyles.caption1.copyWith(color: colors.categoryColor),
           ),
         ],
       ],
@@ -210,17 +387,31 @@ class _LikeButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: 40,
-      height: 40,
-      child: IconButton(
-        padding: EdgeInsets.zero,
-        constraints: const BoxConstraints.tightFor(width: 40, height: 40),
-        splashRadius: 20,
-        onPressed: onPressed,
-        icon: isLiked
-            ? AppIcons.heartFilled(width: 24, height: 24)
-            : AppIcons.heart(width: 24, height: 24),
+    return IconButton(
+      onPressed: onPressed,
+      icon: isLiked
+          ? AppIcons.heartFilled(width: 24, height: 24)
+          : AppIcons.heart(width: 24, height: 24),
+    );
+  }
+}
+
+class _ReviewActionButton extends StatelessWidget {
+  final VoidCallback? onPressed;
+
+  const _ReviewActionButton({
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onPressed,
+      behavior: HitTestBehavior.opaque,
+      child: AppIcons.bin(
+        width: 24,
+        height: 24,
+        color: AppColors.negative,
       ),
     );
   }

--- a/lib/features/map/shared/ui/widgets/review_list_container.dart
+++ b/lib/features/map/shared/ui/widgets/review_list_container.dart
@@ -1,28 +1,33 @@
 import 'package:flutter/material.dart';
+import 'package:goms/core/theme/colors/app_colors.dart';
 import 'package:goms/core/theme/icons/app_icons.dart';
 import 'package:goms/core/theme/layout/app_layout.dart';
 import 'package:goms/core/theme/theme_context.dart';
 import 'package:goms/core/theme/typography/app_text_styles.dart';
-import 'package:goms/core/widgets/dialogs/review_remove_dialog.dart';
+import 'package:goms/core/widgets/dialogs/goms_dialog.dart';
 import 'package:goms/core/widgets/dialogs/review_report_dialog.dart';
 import 'package:intl/intl.dart';
 
 class ReviewListContainer extends StatelessWidget {
+  final int? reviewId;
   final String name;
   final int grade;
   final String major;
   final String reviewDetailContent;
   final DateTime createdAt;
   final bool isMine;
+  final Future<void> Function(int reviewId)? onDelete;
 
   const ReviewListContainer({
     super.key,
+    this.reviewId,
     required this.name,
     required this.grade,
     required this.major,
     required this.reviewDetailContent,
     required this.createdAt,
     required this.isMine,
+    this.onDelete,
   });
 
   @override
@@ -90,11 +95,36 @@ class ReviewListContainer extends StatelessWidget {
             child: isMine
                 ? IconButton(
                     onPressed: () {
-                      reviewRemove(
-                        context: context,
+                      GomsDialog.confirm(
                         title: '후기 삭제',
-                        content: '\n 정말 후기를 삭제하시겠습니까?',
-                      );
+                        content: '정말 후기를 삭제하시겠습니까?',
+                        cancelText: '취소',
+                        confirmText: '삭제',
+                        isDestructive: true,
+                        onConfirm: () async {
+                          if (reviewId == null || onDelete == null) {
+                            return;
+                          }
+
+                          try {
+                            await onDelete!(reviewId!);
+                            if (!context.mounted) return;
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('후기를 삭제했습니다.'),
+                              ),
+                            );
+                          } catch (_) {
+                            if (!context.mounted) return;
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('후기 삭제에 실패했습니다.'),
+                                backgroundColor: AppColors.negative,
+                              ),
+                            );
+                          }
+                        },
+                      ).show(context);
                     },
                     icon: AppIcons.bin(
                       color: context.sub2Color,

--- a/lib/features/member/data/response/profile_image_update_response.g.dart
+++ b/lib/features/member/data/response/profile_image_update_response.g.dart
@@ -7,15 +7,13 @@ part of 'profile_image_update_response.dart';
 // **************************************************************************
 
 ProfileImageUpdateResponse _$ProfileImageUpdateResponseFromJson(
-        Map<String, dynamic> json,
-      ) =>
+        Map<String, dynamic> json) =>
     ProfileImageUpdateResponse(
       imageUrl: json['imageUrl'] as String? ?? '',
     );
 
 Map<String, dynamic> _$ProfileImageUpdateResponseToJson(
-        ProfileImageUpdateResponse instance,
-      ) =>
+        ProfileImageUpdateResponse instance) =>
     <String, dynamic>{
       'imageUrl': instance.imageUrl,
     };

--- a/lib/features/report/data/response/report_response.dart
+++ b/lib/features/report/data/response/report_response.dart
@@ -14,6 +14,8 @@ class ReportResponse {
     required this.reviewerName,
     required this.reviewerGrade,
     required this.reviewerDepartment,
+    required this.placeName,
+    required this.placeAddress,
     required this.reviewerProfileImageUrl,
     required this.reportCreatedAt,
     required this.reportStatus,
@@ -36,6 +38,10 @@ class ReportResponse {
   final int reviewerGrade;
   @JsonKey(fromJson: parseReportString)
   final String reviewerDepartment;
+  @JsonKey(readValue: _readPlaceName, fromJson: parseNullableReportString)
+  final String? placeName;
+  @JsonKey(readValue: _readPlaceAddress, fromJson: parseNullableReportString)
+  final String? placeAddress;
   @JsonKey(readValue: _readReviewerProfileImageUrl, fromJson: parseReportString)
   final String reviewerProfileImageUrl;
   @JsonKey(fromJson: parseReportDateTime)
@@ -55,6 +61,8 @@ class ReportResponse {
       reviewerName: reviewerName,
       reviewerGrade: reviewerGrade,
       reviewerDepartment: reviewerDepartment,
+      placeName: placeName,
+      placeAddress: placeAddress,
       reviewerProfileImageUrl: reviewerProfileImageUrl,
       reportCreatedAt: reportCreatedAt,
       reportStatus: reportStatus,
@@ -69,3 +77,23 @@ Object? _readReviewerProfileImageUrl(Map<dynamic, dynamic> json, String key) =>
     json['reviewerProfileUrl'] ??
     json['profileImageUrl'] ??
     json['profileUrl'];
+
+Object? _readPlaceName(Map<dynamic, dynamic> json, String key) =>
+    json[key] ??
+    json['reviewPlaceName'] ??
+    json['targetPlaceName'] ??
+    _readNestedPlaceField(json, 'placeName');
+
+Object? _readPlaceAddress(Map<dynamic, dynamic> json, String key) =>
+    json[key] ??
+    json['reviewPlaceAddress'] ??
+    json['targetPlaceAddress'] ??
+    _readNestedPlaceField(json, 'address');
+
+Object? _readNestedPlaceField(Map<dynamic, dynamic> json, String key) {
+  final place = json['place'];
+  if (place is Map<dynamic, dynamic>) {
+    return place[key];
+  }
+  return null;
+}

--- a/lib/features/report/data/response/report_response.g.dart
+++ b/lib/features/report/data/response/report_response.g.dart
@@ -14,6 +14,9 @@ ReportResponse _$ReportResponseFromJson(Map<String, dynamic> json) =>
       reviewerName: parseReportString(json['reviewerName']),
       reviewerGrade: parseReportInt(json['reviewerGrade']),
       reviewerDepartment: parseReportString(json['reviewerDepartment']),
+      placeName: parseNullableReportString(_readPlaceName(json, 'placeName')),
+      placeAddress:
+          parseNullableReportString(_readPlaceAddress(json, 'placeAddress')),
       reviewerProfileImageUrl: parseReportString(
           _readReviewerProfileImageUrl(json, 'reviewerProfileImageUrl')),
       reportCreatedAt: parseReportDateTime(json['reportCreatedAt']),

--- a/lib/features/report/ui/models/report_summary_model.dart
+++ b/lib/features/report/ui/models/report_summary_model.dart
@@ -10,6 +10,8 @@ class ReportSummaryModel {
     required this.reviewerName,
     required this.reviewerGrade,
     required this.reviewerDepartment,
+    this.placeName,
+    this.placeAddress,
     this.reviewerProfileImageUrl = '',
     required this.reportCreatedAt,
     required this.reportStatus,
@@ -23,6 +25,8 @@ class ReportSummaryModel {
   final String reviewerName;
   final int reviewerGrade;
   final String reviewerDepartment;
+  final String? placeName;
+  final String? placeAddress;
   final String reviewerProfileImageUrl;
   final DateTime? reportCreatedAt;
   final ReportStatus reportStatus;

--- a/lib/features/report/ui/screens/admin_report_detail_screen.dart
+++ b/lib/features/report/ui/screens/admin_report_detail_screen.dart
@@ -132,13 +132,6 @@ class _AdminReportDetailScreenState
                       ? '리뷰 #${detail.reviewId}'
                       : '리뷰 #${detail.reviewId} $reviewCreatedAt',
                 ),
-                if (detail.deletedAt != null ||
-                    (detail.deletedBy?.isNotEmpty ?? false)) ...[
-                  AppGap.v20,
-                  const _SectionTitle(title: '처리 정보'),
-                  AppGap.v12,
-                  _ResolutionInfo(detail: detail),
-                ],
               ],
             ),
           ),
@@ -304,34 +297,6 @@ class _ReportedUserTile extends StatelessWidget {
           ),
         ),
       ],
-    );
-  }
-}
-
-class _ResolutionInfo extends StatelessWidget {
-  const _ResolutionInfo({required this.detail});
-
-  final ReportDetailModel detail;
-
-  @override
-  Widget build(BuildContext context) {
-    final rows = <String>[
-      if (detail.deletedBy?.isNotEmpty ?? false) '처리자 ${detail.deletedBy}',
-      if (detail.deletedAt != null)
-        '처리 시각 ${DateFormat('yy.MM.dd HH:mm:ss').format(detail.deletedAt!.toLocal())}',
-    ];
-
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
-      decoration: BoxDecoration(
-        color: context.surfaceColor,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Text(
-        rows.isEmpty ? '-' : rows.join('\n'),
-        style: AppTextStyles.text2.copyWith(color: context.sub1Color),
-      ),
     );
   }
 }

--- a/lib/features/report/ui/screens/admin_report_list_screen.dart
+++ b/lib/features/report/ui/screens/admin_report_list_screen.dart
@@ -212,6 +212,8 @@ class _ReportListBody extends ConsumerWidget {
             report.reportId.toString(),
             report.reviewId.toString(),
             _reportHeadline(report),
+            report.placeName ?? '',
+            report.placeAddress ?? '',
           ].join(' ').toLowerCase().contains(normalizedQuery);
 
       return matchesStatus && matchesQuery;
@@ -361,6 +363,20 @@ String _reportHeadline(ReportSummaryModel report) {
 }
 
 String _reportPlaceName(ReportSummaryModel report) {
+  final placeName = report.placeName?.trim();
+  final placeAddress = report.placeAddress?.trim();
+
+  if (placeName != null && placeName.isNotEmpty) {
+    if (placeAddress != null && placeAddress.isNotEmpty) {
+      return '$placeName · $placeAddress';
+    }
+    return placeName;
+  }
+
+  if (placeAddress != null && placeAddress.isNotEmpty) {
+    return placeAddress;
+  }
+
   return '장소 정보 없음';
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,8 +46,6 @@ Future<void> _bootstrapPlatformServices() async {
     debugPrintStack(stackTrace: stackTrace);
   }
 
-  final skipFirebaseOnDebugX86 = await _shouldSkipFirebaseOnDebugX86Android();
-
   try {
     await Firebase.initializeApp(
       options: DefaultFirebaseOptions.currentPlatform,

--- a/test/unit/map_main_overlay_test.dart
+++ b/test/unit/map_main_overlay_test.dart
@@ -5,12 +5,14 @@ import 'package:goms/features/map/domain/entities/my_review_entity.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 import 'package:goms/features/map/data/models/map_coordinate.dart';
 import 'package:goms/features/map/data/providers/recommended_place_providers.dart';
+import 'package:goms/features/map/discovery/ui/models/map_screen_review_model.dart';
 import 'package:goms/features/map/discovery/ui/models/map_screen_state.dart';
 import 'package:goms/features/map/discovery/ui/models/popular_place.dart';
 import 'package:goms/features/map/domain/entities/place_review_entity.dart';
 import 'package:goms/features/map/domain/entities/recommended_place_entity.dart';
 import 'package:goms/features/map/domain/repositories/recommended_place_repository.dart';
 import 'package:goms/features/map/shared/ui/widgets/map_main_overlay.dart';
+import 'package:goms/features/map/shared/ui/widgets/place_container.dart';
 
 void main() {
   testWidgets('tapping a place card forwards the selected place callback', (
@@ -114,6 +116,61 @@ void main() {
     expect(find.text('후기 남기기'), findsOneWidget);
     expect(find.textContaining('339m |'), findsOneWidget);
   });
+
+  testWidgets('my review bin action opens delete confirmation dialog', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          recommendedPlaceRepositoryProvider.overrideWithValue(
+            const _FakeRecommendedPlaceRepository(),
+          ),
+        ],
+        child: MaterialApp(
+          builder: (context, child) => ResponsiveBreakpoints.builder(
+            child: child!,
+            breakpoints: const [
+              Breakpoint(start: 0, end: 359, name: 'SMALL_PHONE'),
+              Breakpoint(start: 360, end: 450, name: 'MOBILE'),
+              Breakpoint(start: 451, end: 800, name: 'TABLET'),
+              Breakpoint(start: 801, end: 1920, name: 'DESKTOP'),
+            ],
+          ),
+          home: Scaffold(
+            body: MapMainOverlay(
+              state: MapScreenState(
+                status: MapScreenStatus.success,
+                reviewModels: [
+                  MapScreenReviewModel(
+                    reviewId: 1,
+                    placeName: '학생식당',
+                    category: '한식',
+                    address: '광주광역시 테스트로 7',
+                    reviewDetailContent: '리뷰 내용',
+                    createdAt: DateTime(2026, 4, 21),
+                  ),
+                ],
+                reviewCount: 1,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final reviewContainer = tester.widget<PlaceContainer>(
+      find.byType(PlaceContainer).last,
+    );
+    reviewContainer.onActionPressed?.call();
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('후기 삭제'), findsOneWidget);
+    expect(find.text('정말 후기를 삭제하시겠습니까?'), findsOneWidget);
+  });
 }
 
 class _FakeRecommendedPlaceRepository implements RecommendedPlaceRepository {
@@ -165,20 +222,11 @@ class _FakeRecommendedPlaceRepository implements RecommendedPlaceRepository {
   Future<bool> unRecommendPlace(int placeId) async => false;
 
   @override
-  Future<void> deleteReview(int reviewId) {
-    // TODO: implement deleteReview
-    throw UnimplementedError();
-  }
+  Future<void> deleteReview(int reviewId) async {}
 
   @override
-  Future<int> getMyReviewCount() {
-    // TODO: implement getMyReviewCount
-    throw UnimplementedError();
-  }
+  Future<int> getMyReviewCount() async => 0;
 
   @override
-  Future<List<MyReviewEntity>> getMyReviews() {
-    // TODO: implement getMyReviews
-    throw UnimplementedError();
-  }
+  Future<List<MyReviewEntity>> getMyReviews() async => const [];
 }

--- a/test/unit/map_main_overlay_test.dart
+++ b/test/unit/map_main_overlay_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:goms/features/map/domain/entities/my_review_entity.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 import 'package:goms/features/map/data/models/map_coordinate.dart';
 import 'package:goms/features/map/data/providers/recommended_place_providers.dart';
@@ -162,4 +163,22 @@ class _FakeRecommendedPlaceRepository implements RecommendedPlaceRepository {
 
   @override
   Future<bool> unRecommendPlace(int placeId) async => false;
+
+  @override
+  Future<void> deleteReview(int reviewId) {
+    // TODO: implement deleteReview
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<int> getMyReviewCount() {
+    // TODO: implement getMyReviewCount
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<MyReviewEntity>> getMyReviews() {
+    // TODO: implement getMyReviews
+    throw UnimplementedError();
+  }
 }

--- a/test/unit/map_recommended_place_unit_test.dart
+++ b/test/unit/map_recommended_place_unit_test.dart
@@ -1,7 +1,11 @@
-import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:goms/features/map/data/datasources/recommended_place_remote_datasource.dart';
 import 'package:goms/features/map/data/repositories/recommended_place_repository_impl.dart';
+import 'package:goms/features/map/data/response/my_review_count_response.dart';
+import 'package:goms/features/map/data/response/my_review_list_response.dart';
+import 'package:goms/features/map/data/response/place_review_list_response.dart';
+import 'package:goms/features/map/data/response/place_recommend_response.dart';
+import 'package:goms/features/map/data/response/recommended_place_count_response.dart';
 import 'package:goms/features/map/data/response/recommended_place_response.dart';
 import 'package:goms/features/map/data/response/recommended_places_response.dart';
 
@@ -68,9 +72,7 @@ void main() {
 }
 
 class _FakeRecommendedPlaceRemoteDataSource
-    extends RecommendedPlaceRemoteDataSource {
-  _FakeRecommendedPlaceRemoteDataSource() : super(Dio());
-
+    implements RecommendedPlaceRemoteDataSource {
   @override
   Future<RecommendedPlacesResponse> getPlaces() async {
     return RecommendedPlacesResponse.fromJson({
@@ -95,5 +97,71 @@ class _FakeRecommendedPlaceRemoteDataSource
         },
       ],
     });
+  }
+
+  @override
+  Future<void> deleteReview(int reviewId) {
+    // TODO: implement deleteReview
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<RecommendedPlacesResponse> getHotPlaces({int? days}) {
+    // TODO: implement getHotPlaces
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<MyReviewListResponse> getMyReviews() {
+    // TODO: implement getMyReviews
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<RecommendedPlaceResponse> getPlaceDetail(int placeId) {
+    // TODO: implement getPlaceDetail
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<PlaceReviewListResponse> getPlaceReviews(int placeId) {
+    // TODO: implement getPlaceReviews
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<RecommendedPlacesResponse> getRecommendedPlaces() {
+    // TODO: implement getRecommendedPlaces
+    throw UnimplementedError();
+  }
+
+  @override
+  @override
+  Future<RecommendedPlacesResponse> searchPlaces(String keyword) {
+    // TODO: implement searchPlaces
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<RecommendedPlaceCountResponse> getRecommendedPlacesCountRaw() async {
+    return const RecommendedPlaceCountResponse(recommendCount: 0);
+  }
+
+  @override
+  Future<PlaceRecommendResponse> recommendPlaceRaw(int placeId) async {
+    return const PlaceRecommendResponse(recommended: true);
+  }
+
+  @override
+  Future<PlaceRecommendResponse> unRecommendPlaceRaw(int placeId) async {
+    return const PlaceRecommendResponse(recommended: false);
+  }
+
+  @override
+  Future<void> createReviewRaw(int placeId, Map<String, dynamic> body) async {}
+
+  @override
+  Future<MyReviewCountResponse> getMyReviewCountRaw() async {
+    return const MyReviewCountResponse(count: 0);
   }
 }

--- a/test/unit/map_recommended_places_unit_test.dart
+++ b/test/unit/map_recommended_places_unit_test.dart
@@ -6,6 +6,7 @@ import 'package:goms/features/map/data/models/map_coordinate.dart';
 import 'package:goms/features/map/data/providers/recommended_place_providers.dart';
 import 'package:goms/features/map/discovery/ui/models/map_screen_state.dart';
 import 'package:goms/features/map/discovery/ui/providers/map_screen_provider.dart';
+import 'package:goms/features/map/domain/entities/my_review_entity.dart';
 import 'package:goms/features/map/domain/entities/place_review_entity.dart';
 import 'package:goms/features/map/domain/entities/recommended_place_entity.dart';
 import 'package:goms/features/map/domain/repositories/recommended_place_repository.dart';
@@ -183,6 +184,24 @@ class _FakeRecommendedPlaceRepository implements RecommendedPlaceRepository {
 
   @override
   Future<bool> unRecommendPlace(int placeId) async => false;
+
+  @override
+  Future<void> deleteReview(int reviewId) {
+    // TODO: implement deleteReview
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<int> getMyReviewCount() {
+    // TODO: implement getMyReviewCount
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<MyReviewEntity>> getMyReviews() {
+    // TODO: implement getMyReviews
+    throw UnimplementedError();
+  }
 }
 
 class _TrackingRecommendedPlaceRepository
@@ -253,6 +272,24 @@ class _ThrowingRecommendedPlaceRepository
 
   @override
   Future<bool> unRecommendPlace(int placeId) async => false;
+
+  @override
+  Future<void> deleteReview(int reviewId) {
+    // TODO: implement deleteReview
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<int> getMyReviewCount() {
+    // TODO: implement getMyReviewCount
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<MyReviewEntity>> getMyReviews() {
+    // TODO: implement getMyReviews
+    throw UnimplementedError();
+  }
 }
 
 class _HotPlaceFailingRepository extends _FakeRecommendedPlaceRepository {

--- a/test/unit/map_recommended_places_unit_test.dart
+++ b/test/unit/map_recommended_places_unit_test.dart
@@ -182,7 +182,7 @@ void main() {
       expect(state.reviewModels.single.reviewId, 12);
     });
 
-    test('keeps local my review state when delete API fails', () async {
+    test('restores my review state when delete API fails', () async {
       final repository = _ReviewDeletingRepository(
         shouldThrowOnDelete: true,
         reviews: [
@@ -223,9 +223,9 @@ void main() {
 
       final state = container.read(mapScreenProvider);
       expect(repository.deletedReviewIds, isEmpty);
-      expect(state.reviewCount, 1);
-      expect(state.reviewModels, hasLength(1));
-      expect(state.reviewModels.single.reviewId, 22);
+      expect(state.reviewCount, 2);
+      expect(state.reviewModels, hasLength(2));
+      expect(state.reviewModels.first.reviewId, 21);
     });
   });
 }

--- a/test/unit/map_recommended_places_unit_test.dart
+++ b/test/unit/map_recommended_places_unit_test.dart
@@ -140,6 +140,93 @@ void main() {
       expect(state.recommendedCount, 0);
       expect(state.popularPlaces, isEmpty);
     });
+
+    test('deletes my review and updates local activity state', () async {
+      final repository = _ReviewDeletingRepository(
+        reviews: [
+          const MyReviewEntity(
+            reviewId: 11,
+            placeId: 101,
+            placeName: '학생식당',
+            categoryName: '한식',
+            address: '광주광역시 테스트로 11',
+            content: '리뷰 1',
+            reviewedAt: null,
+          ),
+          const MyReviewEntity(
+            reviewId: 12,
+            placeId: 102,
+            placeName: '도서관 카페',
+            categoryName: '카페',
+            address: '광주광역시 테스트로 12',
+            content: '리뷰 2',
+            reviewedAt: null,
+          ),
+        ],
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          recommendedPlaceRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(mapScreenProvider.notifier).fetchData();
+      await container.read(mapScreenProvider.notifier).deleteMyReview(11);
+
+      final state = container.read(mapScreenProvider);
+      expect(repository.deletedReviewIds, [11]);
+      expect(state.reviewCount, 1);
+      expect(state.reviewModels, hasLength(1));
+      expect(state.reviewModels.single.reviewId, 12);
+    });
+
+    test('keeps local my review state when delete API fails', () async {
+      final repository = _ReviewDeletingRepository(
+        shouldThrowOnDelete: true,
+        reviews: [
+          const MyReviewEntity(
+            reviewId: 21,
+            placeId: 201,
+            placeName: '기숙사 앞 카페',
+            categoryName: '카페',
+            address: '광주광역시 테스트로 21',
+            content: '리뷰 A',
+            reviewedAt: null,
+          ),
+          const MyReviewEntity(
+            reviewId: 22,
+            placeId: 202,
+            placeName: '분식집',
+            categoryName: '분식',
+            address: '광주광역시 테스트로 22',
+            content: '리뷰 B',
+            reviewedAt: null,
+          ),
+        ],
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          recommendedPlaceRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(mapScreenProvider.notifier).fetchData();
+
+      await expectLater(
+        container.read(mapScreenProvider.notifier).deleteMyReview(21),
+        throwsA(isA<DioException>()),
+      );
+
+      final state = container.read(mapScreenProvider);
+      expect(repository.deletedReviewIds, isEmpty);
+      expect(state.reviewCount, 1);
+      expect(state.reviewModels, hasLength(1));
+      expect(state.reviewModels.single.reviewId, 22);
+    });
   });
 }
 
@@ -186,22 +273,13 @@ class _FakeRecommendedPlaceRepository implements RecommendedPlaceRepository {
   Future<bool> unRecommendPlace(int placeId) async => false;
 
   @override
-  Future<void> deleteReview(int reviewId) {
-    // TODO: implement deleteReview
-    throw UnimplementedError();
-  }
+  Future<void> deleteReview(int reviewId) async {}
 
   @override
-  Future<int> getMyReviewCount() {
-    // TODO: implement getMyReviewCount
-    throw UnimplementedError();
-  }
+  Future<int> getMyReviewCount() async => 0;
 
   @override
-  Future<List<MyReviewEntity>> getMyReviews() {
-    // TODO: implement getMyReviews
-    throw UnimplementedError();
-  }
+  Future<List<MyReviewEntity>> getMyReviews() async => const [];
 }
 
 class _TrackingRecommendedPlaceRepository
@@ -274,21 +352,43 @@ class _ThrowingRecommendedPlaceRepository
   Future<bool> unRecommendPlace(int placeId) async => false;
 
   @override
-  Future<void> deleteReview(int reviewId) {
-    // TODO: implement deleteReview
-    throw UnimplementedError();
-  }
+  Future<void> deleteReview(int reviewId) async {}
 
   @override
-  Future<int> getMyReviewCount() {
-    // TODO: implement getMyReviewCount
-    throw UnimplementedError();
-  }
+  Future<int> getMyReviewCount() async => 0;
 
   @override
-  Future<List<MyReviewEntity>> getMyReviews() {
-    // TODO: implement getMyReviews
-    throw UnimplementedError();
+  Future<List<MyReviewEntity>> getMyReviews() async => const [];
+}
+
+class _ReviewDeletingRepository extends _FakeRecommendedPlaceRepository {
+  _ReviewDeletingRepository({
+    required List<MyReviewEntity> reviews,
+    this.shouldThrowOnDelete = false,
+  })  : _reviews = List<MyReviewEntity>.of(reviews),
+        super(const []);
+
+  final List<MyReviewEntity> _reviews;
+  final bool shouldThrowOnDelete;
+  final List<int> deletedReviewIds = <int>[];
+
+  @override
+  Future<List<MyReviewEntity>> getMyReviews() async =>
+      List<MyReviewEntity>.of(_reviews);
+
+  @override
+  Future<int> getMyReviewCount() async => _reviews.length;
+
+  @override
+  Future<void> deleteReview(int reviewId) async {
+    if (shouldThrowOnDelete) {
+      throw DioException(
+        requestOptions: RequestOptions(path: '/api/v3/review/$reviewId'),
+      );
+    }
+
+    deletedReviewIds.add(reviewId);
+    _reviews.removeWhere((review) => review.reviewId == reviewId);
   }
 }
 


### PR DESCRIPTION
## 💡 개요
지도 추천/내 리뷰 API를 화면 흐름에 연결하고 리뷰 삭제 및 신고 목록 장소 정보 처리를 함께 정리했습니다.

## 🔗 관련 이슈
Closes #97

## 📃 작업내용
- 지도 추천 장소, 내 리뷰 관련 응답 모델과 저장소 연동을 추가했습니다.
- 지도 오버레이, 장소 카드, 리뷰 목록 UI를 API 응답 기반으로 정리했습니다.
- 내 리뷰 삭제 확인 다이얼로그와 삭제 후 목록 갱신 흐름을 추가했습니다.
- 신고 목록에서 장소 정보 파싱 및 표시 로직을 개선했습니다.
- 관련 단위 테스트를 추가하고 generated 파일을 갱신했습니다.

## 🔍 테스트 방법
- `flutter test test/unit/map_main_overlay_test.dart test/unit/map_recommended_place_unit_test.dart test/unit/map_recommended_places_unit_test.dart`
- `flutter analyze` 실행 후 기존 info/warning 10건만 확인했습니다.

## 🖼️ 스크린샷

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 기존 기능이 정상적으로 작동하는지 확인했습니다.
