### PR TITLE
🔀 :: (#112) - 초기 로딩 속도 개선

### DIFF
--- a/lib/features/map/data/kakao_map_runtime.dart
+++ b/lib/features/map/data/kakao_map_runtime.dart
@@ -15,7 +15,6 @@ class KakaoMapRuntime {
   String? _unavailableReason;
   Future<void>? _initFuture;
 
-  bool get isInitialized => _initialized;
   bool get isMapAvailable => _initialized;
   String? get unavailableReason => _unavailableReason;
 

--- a/lib/features/map/data/kakao_map_runtime.dart
+++ b/lib/features/map/data/kakao_map_runtime.dart
@@ -11,20 +11,17 @@ class KakaoMapRuntime {
   static final KakaoMapRuntime instance = KakaoMapRuntime._();
   static const MethodChannel _channel = MethodChannel('goms/device');
 
-  bool _checked = false;
   bool _initialized = false;
   String? _unavailableReason;
+  Future<void>? _initFuture;
 
   bool get isInitialized => _initialized;
   bool get isMapAvailable => _initialized;
   String? get unavailableReason => _unavailableReason;
 
-  Future<void> initialize() async {
-    if (_checked) {
-      return;
-    }
-    _checked = true;
+  Future<void> initialize() => _initFuture ??= _initialize();
 
+  Future<void> _initialize() async {
     if (!Platform.isAndroid && !Platform.isIOS) {
       _unavailableReason = '이 플랫폼에서는 카카오 지도를 지원하지 않습니다.';
       return;

--- a/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
+++ b/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
@@ -63,13 +63,13 @@ class _KakaoMapBackgroundState extends State<KakaoMapBackground> {
     super.initState();
     _ensureMapRuntime();
   }
-  
+
   Future<void> _ensureMapRuntime() async {
-    if (!KakaoMapRuntime.instance.isInitialized) {
+    if (!KakaoMapRuntime.instance.isMapAvailable) {
       await KakaoMapRuntime.instance.initialize();
+      if (!mounted) return;
+      setState(() {});
     }
-    if (!mounted) return;
-    setState(() {});
     _armLoadingTimeout();
   }
 

--- a/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
+++ b/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
@@ -57,11 +57,6 @@ class _KakaoMapBackgroundState extends State<KakaoMapBackground> {
   String? _lastCameraSignature;
   String? _errorMessage;
   Timer? _loadingTimeout;
-  // Whether KakaoMapRuntime.initialize() has settled. Until then the SDK init
-  // (kicked off the startup critical path) may still be in flight, during which
-  // isMapAvailable is false with no unavailableReason — show a loader, not an
-  // error. Stays false on the already-available path, where build() never reads
-  // it because the map renders directly.
   bool _initSettled = false;
 
   @override
@@ -420,8 +415,6 @@ class _KakaoMapBackgroundState extends State<KakaoMapBackground> {
   @override
   Widget build(BuildContext context) {
     if (!KakaoMapRuntime.instance.isMapAvailable) {
-      // initialize() may still be running (it's kicked off the startup critical
-      // path), so show a loader until it settles rather than a misleading error.
       if (!_initSettled) {
         return const Center(child: CircularProgressIndicator());
       }

--- a/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
+++ b/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
@@ -61,6 +61,15 @@ class _KakaoMapBackgroundState extends State<KakaoMapBackground> {
   @override
   void initState() {
     super.initState();
+    _ensureMapRuntime();
+  }
+  
+  Future<void> _ensureMapRuntime() async {
+    if (!KakaoMapRuntime.instance.isInitialized) {
+      await KakaoMapRuntime.instance.initialize();
+    }
+    if (!mounted) return;
+    setState(() {});
     _armLoadingTimeout();
   }
 

--- a/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
+++ b/lib/features/map/shared/presentation/widgets/kakao_map_background.dart
@@ -57,6 +57,12 @@ class _KakaoMapBackgroundState extends State<KakaoMapBackground> {
   String? _lastCameraSignature;
   String? _errorMessage;
   Timer? _loadingTimeout;
+  // Whether KakaoMapRuntime.initialize() has settled. Until then the SDK init
+  // (kicked off the startup critical path) may still be in flight, during which
+  // isMapAvailable is false with no unavailableReason — show a loader, not an
+  // error. Stays false on the already-available path, where build() never reads
+  // it because the map renders directly.
+  bool _initSettled = false;
 
   @override
   void initState() {
@@ -68,7 +74,7 @@ class _KakaoMapBackgroundState extends State<KakaoMapBackground> {
     if (!KakaoMapRuntime.instance.isMapAvailable) {
       await KakaoMapRuntime.instance.initialize();
       if (!mounted) return;
-      setState(() {});
+      setState(() => _initSettled = true);
     }
     _armLoadingTimeout();
   }
@@ -413,8 +419,14 @@ class _KakaoMapBackgroundState extends State<KakaoMapBackground> {
 
   @override
   Widget build(BuildContext context) {
-    final unavailableReason = KakaoMapRuntime.instance.unavailableReason;
     if (!KakaoMapRuntime.instance.isMapAvailable) {
+      // initialize() may still be running (it's kicked off the startup critical
+      // path), so show a loader until it settles rather than a misleading error.
+      if (!_initSettled) {
+        return const Center(child: CircularProgressIndicator());
+      }
+
+      final unavailableReason = KakaoMapRuntime.instance.unavailableReason;
       return Center(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 24),

--- a/lib/features/splash/presentation/screens/splash_screen.dart
+++ b/lib/features/splash/presentation/screens/splash_screen.dart
@@ -55,11 +55,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
     if (!mounted) return;
 
     debugPrint('SplashScreen: navigating to $destination');
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      context.go(destination);
-    });
+    context.go(destination);
   }
 
   @override

--- a/lib/features/splash/presentation/screens/splash_screen.dart
+++ b/lib/features/splash/presentation/screens/splash_screen.dart
@@ -22,7 +22,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   @override
   void initState() {
     super.initState();
-    _checkAuthAndNavigate();
+    Future.microtask(_checkAuthAndNavigate);
   }
 
   Future<void> _checkAuthAndNavigate() async {

--- a/lib/features/splash/presentation/screens/splash_screen.dart
+++ b/lib/features/splash/presentation/screens/splash_screen.dart
@@ -26,9 +26,6 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   }
 
   Future<void> _checkAuthAndNavigate() async {
-    // 스플래시 화면 최소 표시 시간
-    await Future.delayed(const Duration(seconds: 2));
-
     debugPrint('SplashScreen: starting auth check');
 
     final hasToken = await ref.read(authProvider.notifier).checkToken();
@@ -38,10 +35,14 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
     String destination = RoutePath.onboarding;
 
     if (hasToken) {
-      final currentMember = await ref.read(currentMemberProvider.future);
+      final memberFuture = ref.read(currentMemberProvider.future);
+      final cameraLaunchFuture = SettingsStorage.getCameraLaunch();
+      final cameraPermissionFuture = Permission.camera.status;
+
+      final currentMember = await memberFuture;
       final cameraLaunchRoute = CameraLaunchDestinationResolver.resolve(
-        enabled: await SettingsStorage.getCameraLaunch(),
-        isCameraPermissionGranted: (await Permission.camera.status).isGranted,
+        enabled: await cameraLaunchFuture,
+        isCameraPermissionGranted: (await cameraPermissionFuture).isGranted,
         role: currentMember?.role ?? RoleEnum.user,
       );
 

--- a/lib/features/splash/presentation/screens/splash_screen.dart
+++ b/lib/features/splash/presentation/screens/splash_screen.dart
@@ -27,6 +27,11 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
 
   Future<void> _checkAuthAndNavigate() async {
     debugPrint('SplashScreen: starting auth check');
+
+    // Keep the splash visible for at least 1s: if the auth check finishes
+    // sooner we wait out the remainder, otherwise we navigate the moment it's
+    // done. Started here so the floor counts from when the splash appears.
+    final minimumDisplay = Future<void>.delayed(const Duration(seconds: 1));
     String destination = RoutePath.onboarding;
 
     try {
@@ -51,6 +56,8 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
       debugPrintStack(stackTrace: stackTrace);
       destination = RoutePath.onboarding;
     }
+
+    await minimumDisplay;
 
     if (!mounted) return;
 

--- a/lib/features/splash/presentation/screens/splash_screen.dart
+++ b/lib/features/splash/presentation/screens/splash_screen.dart
@@ -28,9 +28,6 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   Future<void> _checkAuthAndNavigate() async {
     debugPrint('SplashScreen: starting auth check');
 
-    // Keep the splash visible for at least 1s: if the auth check finishes
-    // sooner we wait out the remainder, otherwise we navigate the moment it's
-    // done. Started here so the floor counts from when the splash appears.
     final minimumDisplay = Future<void>.delayed(const Duration(seconds: 1));
     String destination = RoutePath.onboarding;
 

--- a/lib/features/splash/presentation/screens/splash_screen.dart
+++ b/lib/features/splash/presentation/screens/splash_screen.dart
@@ -27,27 +27,32 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
 
   Future<void> _checkAuthAndNavigate() async {
     debugPrint('SplashScreen: starting auth check');
-
-    final hasToken = await ref.read(authProvider.notifier).checkToken();
-
-    if (!mounted) return;
-
     String destination = RoutePath.onboarding;
 
-    if (hasToken) {
-      final memberFuture = ref.read(currentMemberProvider.future);
-      final cameraLaunchFuture = SettingsStorage.getCameraLaunch();
-      final cameraPermissionFuture = Permission.camera.status;
+    try {
+      final hasToken = await ref.read(authProvider.notifier).checkToken();
 
-      final currentMember = await memberFuture;
-      final cameraLaunchRoute = CameraLaunchDestinationResolver.resolve(
-        enabled: await cameraLaunchFuture,
-        isCameraPermissionGranted: (await cameraPermissionFuture).isGranted,
-        role: currentMember?.role ?? RoleEnum.user,
-      );
+      if (hasToken) {
+        final memberFuture = ref.read(currentMemberProvider.future);
+        final cameraLaunchFuture = SettingsStorage.getCameraLaunch();
+        final cameraPermissionFuture = Permission.camera.status;
 
-      destination = cameraLaunchRoute ?? RoutePath.home;
+        final currentMember = await memberFuture;
+        final cameraLaunchRoute = CameraLaunchDestinationResolver.resolve(
+          enabled: await cameraLaunchFuture,
+          isCameraPermissionGranted: (await cameraPermissionFuture).isGranted,
+          role: currentMember?.role ?? RoleEnum.user,
+        );
+
+        destination = cameraLaunchRoute ?? RoutePath.home;
+      }
+    } catch (error, stackTrace) {
+      debugPrint('SplashScreen: auth check failed, falling back to onboarding: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      destination = RoutePath.onboarding;
     }
+
+    if (!mounted) return;
 
     debugPrint('SplashScreen: navigating to $destination');
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
@@ -16,14 +18,7 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
 }
 
-Future<void> _bootstrapPlatformServices() async {
-  try {
-    await KakaoMapRuntime.instance.initialize();
-  } catch (error, stackTrace) {
-    debugPrint('KakaoMap bootstrap failed: $error');
-    debugPrintStack(stackTrace: stackTrace);
-  }
-
+Future<void> _initFirebase() async {
   try {
     await Firebase.initializeApp(
       options: DefaultFirebaseOptions.currentPlatform,
@@ -35,14 +30,33 @@ Future<void> _bootstrapPlatformServices() async {
   }
 }
 
+Future<void> _initKakaoMap() async {
+  try {
+    await KakaoMapRuntime.instance.initialize();
+  } catch (error, stackTrace) {
+    debugPrint('KakaoMap bootstrap failed: $error');
+    debugPrintStack(stackTrace: stackTrace);
+  }
+}
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   const appEnvValue = String.fromEnvironment('APP_ENV', defaultValue: 'dev');
   final appEnv = AppEnv.fromValue(appEnvValue);
 
-  await dotenv.load(fileName: appEnv.fileName);
-  await _bootstrapPlatformServices();
+  // dotenv must be ready before the first frame (providers read env on build);
+  // Firebase doesn't depend on it, so overlap the two to keep startup short.
+  await Future.wait([
+    dotenv.load(fileName: appEnv.fileName),
+    _initFirebase(),
+  ]);
+
   runApp(const ProviderScope(child: MyApp()));
+
+  // The Kakao Map SDK is only used on the map screen and its native init is
+  // expensive, so initialize it off the startup critical path. The map widget
+  // lazily awaits this same (idempotent) call before it renders.
+  unawaited(_initKakaoMap());
 }
 
 class MyApp extends ConsumerWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,18 +44,12 @@ Future<void> main() async {
   const appEnvValue = String.fromEnvironment('APP_ENV', defaultValue: 'dev');
   final appEnv = AppEnv.fromValue(appEnvValue);
 
-  // dotenv must be ready before the first frame (providers read env on build);
-  // Firebase doesn't depend on it, so overlap the two to keep startup short.
   await Future.wait([
     dotenv.load(fileName: appEnv.fileName),
     _initFirebase(),
   ]);
 
   runApp(const ProviderScope(child: MyApp()));
-
-  // The Kakao Map SDK is only used on the map screen and its native init is
-  // expensive, so initialize it off the startup critical path. The map widget
-  // lazily awaits this same (idempotent) call before it renders.
   unawaited(_initKakaoMap());
 }
 


### PR DESCRIPTION
## 💡 개요
스플래시 화면이 너무 길어 앱 시작 로딩 속도를 개선했습니다.

## 🔗 관련 이슈
Closes #112

## 📃 작업내용
- 스플래시 강제 대기(2초)를 제거하고 인증 체크 흐름을 병렬화했습니다.
- 시작 시 카카오맵 SDK 초기화를 첫 프레임 이후로 분리하고, dotenv/Firebase를 병렬 초기화했습니다.
- 카카오맵은 지도 화면 진입 시 지연 초기화되도록 보장했습니다.