### PR TITLE
🔀 :: (#116) - QR 발급 화면 돌아가기 버튼 및 삼성 바텀 네비 겹침 수정

### DIFF
--- a/lib/core/widgets/appbar/goms_app_bar.dart
+++ b/lib/core/widgets/appbar/goms_app_bar.dart
@@ -57,7 +57,10 @@ class GomsAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
-    final backAction = onBackPressed ?? () => context.pop();
+    // context.go 진입(예: 카메라 바로 켜기)으로 back stack이 없을 때 pop이
+    // 무동작이 되므로 홈으로 폴백한다.
+    final backAction = onBackPressed ??
+        () => context.canPop() ? context.pop() : context.go(RoutePath.home);
 
     return AppBar(
       automaticallyImplyLeading: false,

--- a/lib/core/widgets/appbar/goms_app_bar.dart
+++ b/lib/core/widgets/appbar/goms_app_bar.dart
@@ -74,6 +74,8 @@ class GomsAppBar extends StatelessWidget implements PreferredSizeWidget {
                 style: TextButton.styleFrom(
                   padding: EdgeInsets.zero,
                   alignment: Alignment.centerLeft,
+                  splashFactory: NoSplash.splashFactory,
+                  overlayColor: Colors.transparent,
                 ),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,

--- a/lib/core/widgets/goms_bottom_navigation.dart
+++ b/lib/core/widgets/goms_bottom_navigation.dart
@@ -24,15 +24,16 @@ class GomsBottomNavigation extends StatelessWidget {
       hoverColor: Colors.transparent,
     );
 
+    // ponytail: SafeArea(padding)는 상위에서 소비되거나 기기/OS별로 0으로
+    // 리포팅되면 안 밀어올려 일부 기기에서 시스템 네비바와 겹쳤다. 소비/편차의
+    // 영향을 안 받는 물리 인셋 viewPadding을 직접 더해 기기 편차를 없앤다.
+    final bottomInset = MediaQuery.viewPaddingOf(context).bottom;
+
     return Theme(
       data: noTouchEffectTheme,
-      // 엣지투엣지(삼성 One UI 제스처바 등)에서 시스템 하단 inset만큼 밀어올려
-      // 아이콘이 시스템 네비바 뒤로 가려지지 않게 한다.
-      child: SafeArea(
-        top: false,
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 52, vertical: 24),
-          child: Row(
+      child: Container(
+        padding: EdgeInsets.fromLTRB(52, 24, 52, 24 + bottomInset),
+        child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               GestureDetector(
@@ -50,7 +51,6 @@ class GomsBottomNavigation extends StatelessWidget {
             ],
           ),
         ),
-      ),
     );
   }
 }

--- a/lib/core/widgets/goms_bottom_navigation.dart
+++ b/lib/core/widgets/goms_bottom_navigation.dart
@@ -26,24 +26,29 @@ class GomsBottomNavigation extends StatelessWidget {
 
     return Theme(
       data: noTouchEffectTheme,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 52, vertical: 24),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            GestureDetector(
-              onTap: () => onTap(0),
-              child: AppIcons.map(width: 24, height: 24, color: currentIndex == 0 ? selectedColor : unselectedColor),
-            ),
-            GestureDetector(
-              onTap: () => onTap(1),
-              child: AppIcons.home(width: 24, height: 24, color: currentIndex == 1 ? selectedColor : unselectedColor),
-            ),
-            GestureDetector(
-              onTap: () => onTap(2),
-              child: AppIcons.user(width: 24, height: 24, color: currentIndex == 2 ? selectedColor : unselectedColor),
-            ),
-          ],
+      // 엣지투엣지(삼성 One UI 제스처바 등)에서 시스템 하단 inset만큼 밀어올려
+      // 아이콘이 시스템 네비바 뒤로 가려지지 않게 한다.
+      child: SafeArea(
+        top: false,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 52, vertical: 24),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              GestureDetector(
+                onTap: () => onTap(0),
+                child: AppIcons.map(width: 24, height: 24, color: currentIndex == 0 ? selectedColor : unselectedColor),
+              ),
+              GestureDetector(
+                onTap: () => onTap(1),
+                child: AppIcons.home(width: 24, height: 24, color: currentIndex == 1 ? selectedColor : unselectedColor),
+              ),
+              GestureDetector(
+                onTap: () => onTap(2),
+                child: AppIcons.user(width: 24, height: 24, color: currentIndex == 2 ? selectedColor : unselectedColor),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## 💡 개요
QR 발급 화면에서 돌아가기 버튼이 동작하지 않던 문제와, 삼성 등 일부 기기에서 하단 바텀 네비게이션이 시스템 네비게이션 바와 겹치던 문제를 수정했습니다.

## 🔗 관련 이슈
Closes #116

## 📃 작업내용
- **돌아가기 폴백**: `context.go` 진입(예: 카메라 바로 켜기)으로 back stack이 없을 때 `context.pop()`이 무동작이 되던 문제를, `canPop()` 여부에 따라 pop 또는 홈으로 폴백하도록 수정 (`goms_app_bar.dart`)
- **탭 애니메이션 제거**: 돌아가기 버튼의 splash/overlay 효과를 제거해 불필요한 탭 애니메이션을 없앰
- **바텀 네비 겹침 수정**: `SafeArea` padding이 상위에서 소비되거나 기기/OS별로 0으로 리포팅되어 겹치던 문제를, 물리 인셋인 `MediaQuery.viewPaddingOf(context).bottom`을 직접 더하는 방식으로 변경해 기기 편차를 제거 (`goms_bottom_navigation.dart`)

## 🔍 테스트 방법
- QR 발급 화면에 카메라 바로 켜기로 진입 후 돌아가기 버튼 → 홈으로 정상 이동 확인
- 삼성 기기(제스처/버튼 네비게이션 모두)에서 바텀 네비가 시스템 바와 겹치지 않는지 확인

## 🖼️ 스크린샷
<!-- 필요 시 첨부 -->

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 기존 기능이 정상적으로 작동하는지 확인했습니다.
