### PR TITLE
🔀 :: 학생회 권한 학생에게도 강제외출/복귀 토글 노출

### DIFF
--- a/lib/features/outing/presentation/screens/admin_outing_state_screen.dart
+++ b/lib/features/outing/presentation/screens/admin_outing_state_screen.dart
@@ -927,37 +927,36 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (uiState.currentRole == StudentRole.student)
-            _UserRoleBottomSheetItem(
-              title: '외출',
-              description: '학생들 외출/복귀 시켜요.',
-              trailing: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: ToggleButton(
-                  type: RoleEnum.admin,
-                  value: uiState.isOuting,
-                  onChanged: uiState.isSubmitting
-                      ? (_) {}
-                      : (_) {
-                          if (uiState.isOuting) {
-                            forcedOutingRelease(
-                              context: context,
-                              title: '강제외출 복귀',
-                              content: '\n 학생을 복귀 상태로 변경하시겠습니까?',
-                              onConfirm: _releaseForcedOuting,
-                            );
-                          } else {
-                            forcedOuting(
-                              context: context,
-                              title: '강제외출',
-                              content: '\n 이 학생을 외출 상태로 변경하시겠습니까?',
-                              onConfirm: _forceOut,
-                            );
-                          }
-                        },
-                ),
+          _UserRoleBottomSheetItem(
+            title: '외출',
+            description: '학생들 외출/복귀 시켜요.',
+            trailing: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: ToggleButton(
+                type: RoleEnum.admin,
+                value: uiState.isOuting,
+                onChanged: uiState.isSubmitting
+                    ? (_) {}
+                    : (_) {
+                        if (uiState.isOuting) {
+                          forcedOutingRelease(
+                            context: context,
+                            title: '강제외출 복귀',
+                            content: '\n 학생을 복귀 상태로 변경하시겠습니까?',
+                            onConfirm: _releaseForcedOuting,
+                          );
+                        } else {
+                          forcedOuting(
+                            context: context,
+                            title: '강제외출',
+                            content: '\n 이 학생을 외출 상태로 변경하시겠습니까?',
+                            onConfirm: _forceOut,
+                          );
+                        }
+                      },
               ),
             ),
+          ),
           if (uiState.currentRole == StudentRole.student ||
               uiState.currentRole == StudentRole.outingBanned) ...[
             AppGap.v12,

--- a/lib/features/outing/presentation/screens/admin_outing_state_screen.dart
+++ b/lib/features/outing/presentation/screens/admin_outing_state_screen.dart
@@ -927,36 +927,37 @@ class _UserRoleBottomSheetState extends ConsumerState<UserRoleBottomSheet> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _UserRoleBottomSheetItem(
-            title: '외출',
-            description: '학생들 외출/복귀 시켜요.',
-            trailing: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: ToggleButton(
-                type: RoleEnum.admin,
-                value: uiState.isOuting,
-                onChanged: uiState.isSubmitting
-                    ? (_) {}
-                    : (_) {
-                        if (uiState.isOuting) {
-                          forcedOutingRelease(
-                            context: context,
-                            title: '강제외출 복귀',
-                            content: '\n 학생을 복귀 상태로 변경하시겠습니까?',
-                            onConfirm: _releaseForcedOuting,
-                          );
-                        } else {
-                          forcedOuting(
-                            context: context,
-                            title: '강제외출',
-                            content: '\n 이 학생을 외출 상태로 변경하시겠습니까?',
-                            onConfirm: _forceOut,
-                          );
-                        }
-                      },
+          if (uiState.currentRole != StudentRole.outingBanned)
+            _UserRoleBottomSheetItem(
+              title: '외출',
+              description: '학생들 외출/복귀 시켜요.',
+              trailing: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: ToggleButton(
+                  type: RoleEnum.admin,
+                  value: uiState.isOuting,
+                  onChanged: uiState.isSubmitting
+                      ? (_) {}
+                      : (_) {
+                          if (uiState.isOuting) {
+                            forcedOutingRelease(
+                              context: context,
+                              title: '강제외출 복귀',
+                              content: '\n 학생을 복귀 상태로 변경하시겠습니까?',
+                              onConfirm: _releaseForcedOuting,
+                            );
+                          } else {
+                            forcedOuting(
+                              context: context,
+                              title: '강제외출',
+                              content: '\n 이 학생을 외출 상태로 변경하시겠습니까?',
+                              onConfirm: _forceOut,
+                            );
+                          }
+                        },
+                ),
               ),
             ),
-          ),
           if (uiState.currentRole == StudentRole.student ||
               uiState.currentRole == StudentRole.outingBanned) ...[
             AppGap.v12,


### PR DESCRIPTION
## 💡 개요
학생 관리 바텀시트에서 학생회(관리자) 권한 학생에게도 강제외출/복귀 토글을 노출합니다.

## 🔗 관련 이슈
없음

## 📃 작업내용
- 외출 토글에 걸려 있던 `currentRole == StudentRole.student` 가드 제거로 학생회 권한 학생도 토글 노출
- 리뷰 반영: 가드를 완전히 제거하지 않고 `currentRole != StudentRole.outingBanned` 조건으로 변경 — 학생회는 노출, 외출금지 학생은 제외

## 🔍 테스트 방법
- `flutter analyze` (해당 파일) → No issues
- `flutter test test/widget/admin_outing_state_screen_widget_test.dart` → 2 passed
- 학생회 권한 학생 관리 시 외출 토글 노출 / 외출금지 학생은 미노출 확인

## 🖼️ 스크린샷
_해당 없음_

## 🙋‍♂️ 질문사항
- 없음

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 기존 기능이 정상적으로 작동하는지 확인했습니다.
