### PR TITLE
🔀 :: openAppSettings 무한 재귀 크래시 수정

### DIFF
--- a/lib/core/data/services_impl/permission_service_impl.dart
+++ b/lib/core/data/services_impl/permission_service_impl.dart
@@ -54,5 +54,5 @@ class PermissionServiceImpl implements PermissionService {
       Permission.location.status;
 
   @override
-  Future<void> openAppSettings() async => await ph.openAppSettings();
+  Future<void> openAppSettings() => ph.openAppSettings();
 }

--- a/lib/core/data/services_impl/permission_service_impl.dart
+++ b/lib/core/data/services_impl/permission_service_impl.dart
@@ -1,4 +1,6 @@
 import 'package:permission_handler/permission_handler.dart';
+import 'package:permission_handler/permission_handler.dart' as ph
+    show openAppSettings;
 import 'package:goms/core/domain/services/permission_service.dart';
 
 /// PermissionService의 구현체
@@ -52,5 +54,5 @@ class PermissionServiceImpl implements PermissionService {
       Permission.location.status;
 
   @override
-  Future<void> openAppSettings() async => await openAppSettings();
+  Future<void> openAppSettings() async => await ph.openAppSettings();
 }


### PR DESCRIPTION
## 💡 개요
권한 영구거부 시 앱 설정 화면으로 이동하려 할 때 발생하는 무한 재귀(StackOverflow) 크래시를 수정합니다. (#118 릴리즈 리뷰 CRITICAL 반영)

## 🔗 관련 이슈
없음

## 📃 작업내용
- `PermissionServiceImpl.openAppSettings()`가 자기 자신을 호출해 무한 재귀 → StackOverflowError
- `permission_handler`의 탑레벨 `openAppSettings`를 `as ph`로 임포트해 위임하도록 수정
- 알림/카메라/위치 권한 영구거부 분기(13/25/37라인)에서 설정 화면 진입 시 크래시 해결

## 🔍 테스트 방법
- `flutter analyze` → No issues
- 권한 영구거부 상태에서 권한 요청 → 설정 화면 정상 이동(크래시 없음)

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 기존 기능이 정상적으로 작동하는지 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)