### PR TITLE
🔀 :: v1.4.3 - 동기화 후 stale 권한 문제 수정

### DIFF
--- a/.github/workflows/flutter-ci.yaml
+++ b/.github/workflows/flutter-ci.yaml
@@ -51,15 +51,3 @@ jobs:
 
       - name: Run tests
         run: flutter test
-
-      - name: Build Android APK
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: flutter build apk --release
-
-      - name: Upload APK
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-apk
-          path: build/app/outputs/flutter-apk/app-release.apk
-          if-no-files-found: warn

--- a/lib/features/auth/session/presentation/viewmodels/session_viewmodel.dart
+++ b/lib/features/auth/session/presentation/viewmodels/session_viewmodel.dart
@@ -83,6 +83,9 @@ class AuthNotifier extends Notifier<AuthStatus> {
   Future<bool> _loadSession() async {
     try {
       await _fetchCurrentMember();
+      // 프로필 role은 access token claim에 의존할 수 있어, 서버 DB 기준
+      // /member/myrole로 권한을 한 번 더 보정한다. (이슈 #123)
+      await ref.read(currentMemberProvider.notifier).refreshRole();
       _warmUpHomeData();
       state = AuthStatus.authenticated;
       return true;

--- a/lib/features/auth/session/presentation/viewmodels/session_viewmodel.dart
+++ b/lib/features/auth/session/presentation/viewmodels/session_viewmodel.dart
@@ -16,6 +16,12 @@ enum AuthStatus {
   checking,
 }
 
+/// 재발급(reissue) 시도 결과.
+/// - [success]: 새 토큰 저장 완료
+/// - [rejected]: 리프레시 토큰이 서버에서 거부됨(401/403) → 세션 종료
+/// - [transient]: 일시 장애(타임아웃·연결·5xx 등) → 토큰 보존
+enum _ReissueOutcome { success, rejected, transient }
+
 final authProvider = NotifierProvider<AuthNotifier, AuthStatus>(() {
   return AuthNotifier();
 });
@@ -37,55 +43,76 @@ class AuthNotifier extends Notifier<AuthStatus> {
 
   Future<bool> checkToken() async {
     state = AuthStatus.checking;
-    final accessToken = await TokenStorage.getAccessToken();
-    final accessTokenExpiry = await TokenStorage.getAccessTokenExpiry();
-
-    if (_hasValidToken(accessToken, accessTokenExpiry)) {
-      try {
-        await _fetchCurrentMember();
-        _warmUpHomeData();
-        state = AuthStatus.authenticated;
-        return true;
-      } catch (_) {
-        _clearSessionState();
-        return false;
-      }
-    }
 
     final refreshToken = await TokenStorage.getRefreshToken();
     final refreshTokenExpiry = await TokenStorage.getRefreshTokenExpiry();
+    final hasValidRefresh = _hasValidToken(refreshToken, refreshTokenExpiry);
 
-    if (!_hasValidToken(refreshToken, refreshTokenExpiry)) {
-      await _clearSession();
-      return false;
+    // 리프레시 토큰이 유효하면 access token의 만료 여부와 관계없이 항상 재발급을
+    // 먼저 시도한다. 디스코드 권한 동기화 후에도 기존 access token의 role claim이
+    // 남아 이전 권한(학생회 등)이 계속 보이던 문제를 막기 위함이다. 재발급으로
+    // role claim을 최신화한 뒤 멤버 정보를 다시 불러온다. (이슈 #123)
+    if (hasValidRefresh) {
+      final outcome = await _reissue(refreshToken!);
+      if (outcome == _ReissueOutcome.success) {
+        return _loadSession();
+      }
+      if (outcome == _ReissueOutcome.rejected) {
+        // 리프레시 토큰이 서버에서 거부됨 → 세션은 이미 종료되었다.
+        return false;
+      }
+      // 일시 장애: 아직 유효한 access token이 있으면 그걸로 폴백한다.
     }
 
+    final accessToken = await TokenStorage.getAccessToken();
+    final accessTokenExpiry = await TokenStorage.getAccessTokenExpiry();
+    if (_hasValidToken(accessToken, accessTokenExpiry)) {
+      return _loadSession();
+    }
+
+    if (hasValidRefresh) {
+      // 재발급이 일시적으로 실패했을 뿐 리프레시 토큰은 유효하므로 토큰을 보존해
+      // 다음 실행 때 다시 재발급을 시도할 수 있게 한다.
+      _clearSessionState();
+    } else {
+      await _clearSession();
+    }
+    return false;
+  }
+
+  Future<bool> _loadSession() async {
+    try {
+      await _fetchCurrentMember();
+      _warmUpHomeData();
+      state = AuthStatus.authenticated;
+      return true;
+    } catch (_) {
+      _clearSessionState();
+      return false;
+    }
+  }
+
+  Future<_ReissueOutcome> _reissue(String refreshToken) async {
     try {
       final response = await ref.read(sessionRemoteDataSourceProvider).reissue(
-            'Bearer ${refreshToken!.trim()}',
+            'Bearer ${refreshToken.trim()}',
           );
       await TokenStorage.saveAccessToken(response.accessToken);
       await TokenStorage.saveRefreshToken(response.refreshToken);
       await TokenStorage.saveAccessTokenExpiry(response.accessTokenExpiresIn);
       await TokenStorage.saveRefreshTokenExpiry(response.refreshTokenExpiresIn);
-      await _fetchCurrentMember();
-      _warmUpHomeData();
-      state = AuthStatus.authenticated;
-      return true;
+      return _ReissueOutcome.success;
     } on DioException catch (error) {
       if (_isRefreshRejected(error)) {
         // 리프레시 토큰이 서버에서 실제로 거부된 경우에만 토큰을 삭제한다.
         await _clearSession();
-      } else {
-        // 타임아웃·연결 오류·서버 일시 오류 등에서는 토큰을 보존해
-        // 다음 실행 때 다시 재발급을 시도할 수 있게 한다.
-        _clearSessionState();
+        return _ReissueOutcome.rejected;
       }
-      return false;
+      // 타임아웃·연결 오류·서버 일시 오류 등에서는 토큰을 보존한다.
+      return _ReissueOutcome.transient;
     } catch (_) {
       // 예기치 못한 오류에서도 토큰은 보존한다.
-      _clearSessionState();
-      return false;
+      return _ReissueOutcome.transient;
     }
   }
 

--- a/lib/features/member/data/datasources/member_remote_datasource.dart
+++ b/lib/features/member/data/datasources/member_remote_datasource.dart
@@ -18,6 +18,9 @@ abstract class MemberRemoteDataSource {
   @GET('/api/v3/member/profile')
   Future<CurrentMemberDto> getMyProfile();
 
+  @GET('/api/v3/member/myrole')
+  Future<CurrentMemberDto> getMyRole();
+
   @GET('/api/v3/student-council/member')
   Future<StudentCouncilStudentsResponse> getStudentCouncilMembers();
 

--- a/lib/features/member/data/datasources/member_remote_datasource.g.dart
+++ b/lib/features/member/data/datasources/member_remote_datasource.g.dart
@@ -76,6 +76,33 @@ class _MemberRemoteDataSource implements MemberRemoteDataSource {
   }
 
   @override
+  Future<CurrentMemberDto> getMyRole() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<CurrentMemberDto>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/v3/member/myrole',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late CurrentMemberDto _value;
+    try {
+      _value = CurrentMemberDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
   Future<StudentCouncilStudentsResponse> getStudentCouncilMembers() async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};

--- a/lib/features/member/data/repositories/member_repository_impl.dart
+++ b/lib/features/member/data/repositories/member_repository_impl.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/features/member/data/datasources/member_remote_datasource.dart';
 import 'package:goms/features/member/data/request/student_council_filter_request.dart';
 import 'package:goms/features/member/domain/entities/current_member_entity.dart';
@@ -21,6 +22,12 @@ class MemberRepositoryImpl implements MemberRepository {
   Future<CurrentMemberEntity> getMyProfile() async {
     final currentMember = await _remoteDataSource.getMyProfile();
     return currentMember.toEntity();
+  }
+
+  @override
+  Future<RoleEnum> getMyRole() async {
+    final myRole = await _remoteDataSource.getMyRole();
+    return myRole.role;
   }
 
   @override

--- a/lib/features/member/domain/repositories/member_repository.dart
+++ b/lib/features/member/domain/repositories/member_repository.dart
@@ -1,3 +1,4 @@
+import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/features/member/data/request/student_council_filter_request.dart';
 import 'package:goms/features/member/domain/entities/current_member_entity.dart';
 import 'package:goms/features/member/domain/entities/member_entity.dart';
@@ -7,6 +8,10 @@ abstract class MemberRepository {
   Future<List<MemberEntity>> getMembers();
 
   Future<CurrentMemberEntity> getMyProfile();
+
+  /// 서버 DB 기준 최신 권한을 조회한다. access token의 role claim이 아니라
+  /// 서버가 보관한 role을 반환하므로 동기화 직후 stale 권한 보정에 사용한다.
+  Future<RoleEnum> getMyRole();
 
   Future<List<StudentCouncilStudentEntity>> getStudentCouncilMembers({
     String? query,

--- a/lib/features/member/presentation/providers/current_member_provider.dart
+++ b/lib/features/member/presentation/providers/current_member_provider.dart
@@ -46,8 +46,18 @@ class CurrentMemberNotifier extends AsyncNotifier<CurrentMemberEntity?> {
 
     try {
       final role = await ref.read(memberRepositoryProvider).getMyRole();
-      if (role != currentMember.role) {
-        state = AsyncData(currentMember.copyWith(role: role));
+
+      // await 동안 상태가 바뀌었을 수 있다(로그아웃으로 clear() 호출 등).
+      // 캡처해둔 값으로 덮어쓰면 종료된 세션이 부활할 수 있으므로 최신 상태를
+      // 다시 확인하고, null이거나 다른 멤버로 바뀌었으면 보정을 중단한다.
+      final latestMember = state.asData?.value;
+      if (latestMember == null ||
+          latestMember.memberId != currentMember.memberId) {
+        return;
+      }
+
+      if (role != latestMember.role) {
+        state = AsyncData(latestMember.copyWith(role: role));
       }
     } catch (error, stackTrace) {
       // 권한 보정 실패는 세션을 막지 않고 프로필 role을 그대로 사용한다.

--- a/lib/features/member/presentation/providers/current_member_provider.dart
+++ b/lib/features/member/presentation/providers/current_member_provider.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:goms/core/network/network_exception.dart';
+import 'package:goms/core/utils/logger.dart';
 import 'package:goms/features/member/data/providers/member_providers.dart';
 import 'package:goms/features/member/domain/entities/current_member_entity.dart';
 
@@ -32,6 +33,31 @@ class CurrentMemberNotifier extends AsyncNotifier<CurrentMemberEntity?> {
     } catch (error, stackTrace) {
       state = AsyncError(error, stackTrace);
       rethrow;
+    }
+  }
+
+  /// 서버 DB 기준 최신 권한(role)을 조회해 현재 멤버에 덮어쓴다.
+  /// 권한 조회 실패는 무시하고 기존 프로필 role을 유지한다(best-effort 보정).
+  Future<void> refreshRole() async {
+    final currentMember = state.asData?.value;
+    if (currentMember == null) {
+      return;
+    }
+
+    try {
+      final role = await ref.read(memberRepositoryProvider).getMyRole();
+      if (role != currentMember.role) {
+        state = AsyncData(currentMember.copyWith(role: role));
+      }
+    } catch (error, stackTrace) {
+      // 권한 보정 실패는 세션을 막지 않고 프로필 role을 그대로 사용한다.
+      // 다만 원인 파악을 위해 로그는 남긴다.
+      Logger.e(
+        'refreshRole failed: $error',
+        tag: 'MEMBER',
+        error: error,
+        stackTrace: stackTrace,
+      );
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # Read more about Android versioning at https://developer.android.com/studio/publish/versioning
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.4.2+46
+version: 1.4.3+47
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/test/unit/session_reissue_on_launch_unit_test.dart
+++ b/test/unit/session_reissue_on_launch_unit_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:goms/core/enums/role_enum.dart';
+import 'package:goms/features/auth/session/data/datasources/session_remote_datasource.dart';
+import 'package:goms/features/auth/session/data/providers/session_data_providers.dart';
+import 'package:goms/features/auth/session/data/request/signin/signin_request_dto.dart';
+import 'package:goms/features/auth/session/data/response/signin/signin_response_dto.dart';
+import 'package:goms/features/auth/session/presentation/viewmodels/session_viewmodel.dart';
+import 'package:goms/features/member/data/providers/member_providers.dart';
+import 'package:goms/features/member/domain/entities/current_member_entity.dart';
+import 'package:goms/features/member/domain/repositories/member_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const secureStorageChannel = MethodChannel(
+    'plugins.it_nomads.com/flutter_secure_storage',
+  );
+
+  final storage = <String, String?>{};
+
+  Future<Object?> secureStorageHandler(MethodCall call) async {
+    final arguments = Map<String, dynamic>.from(
+      (call.arguments as Map?)?.cast<String, dynamic>() ?? const {},
+    );
+    final key = arguments['key'] as String?;
+    switch (call.method) {
+      case 'read':
+        return storage[key];
+      case 'write':
+        if (key != null) storage[key] = arguments['value'] as String?;
+        return null;
+      case 'delete':
+        if (key != null) storage.remove(key);
+        return null;
+      case 'deleteAll':
+        storage.clear();
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  setUp(() {
+    storage.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(secureStorageChannel, secureStorageHandler);
+  });
+
+  tearDown(() {
+    storage.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(secureStorageChannel, null);
+  });
+
+  test(
+    'checkToken가 유효한 access token이 있어도 reissue를 먼저 호출해 권한을 최신화한다 (#123)',
+    () async {
+      final future = DateTime.now().toUtc().add(const Duration(days: 1));
+      // 동기화 전 발급된, 아직 만료되지 않은 access token 상황을 재현한다.
+      storage['access_token'] = 'stale-access-token';
+      storage['access_token_expiry'] = future.toIso8601String();
+      storage['refresh_token'] = 'valid-refresh-token';
+      storage['refresh_token_expiry'] = future.toIso8601String();
+
+      final session = _RecordingSessionDataSource();
+      final repository = _FakeMemberRepository(role: RoleEnum.user);
+
+      final container = ProviderContainer(
+        overrides: [
+          sessionRemoteDataSourceProvider.overrideWithValue(session),
+          memberRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(authProvider.notifier).checkToken();
+
+      expect(result, isTrue);
+      // access token이 유효했음에도 재발급이 강제로 일어나야 한다.
+      expect(session.reissueCalls, 1);
+      expect(storage['access_token'], 'renewed-access-token');
+      expect(storage['refresh_token'], 'renewed-refresh-token');
+      // 최신 role이 반영된다.
+      expect(container.read(authProvider), AuthStatus.authenticated);
+    },
+  );
+}
+
+class _RecordingSessionDataSource implements SessionRemoteDataSource {
+  int reissueCalls = 0;
+
+  @override
+  Future<SignInResponseDto> reissue(String refreshToken) async {
+    reissueCalls++;
+    final future = DateTime.now().toUtc().add(const Duration(days: 1));
+    return SignInResponseDto(
+      accessToken: 'renewed-access-token',
+      refreshToken: 'renewed-refresh-token',
+      accessTokenExpiresIn: future,
+      refreshTokenExpiresIn: future,
+    );
+  }
+
+  @override
+  Future<SignInResponseDto> signIn(SignInRequestDto requestDto) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> signOut(String refreshToken) => throw UnimplementedError();
+}
+
+class _FakeMemberRepository implements MemberRepository {
+  _FakeMemberRepository({required this.role});
+
+  final RoleEnum role;
+
+  @override
+  Future<CurrentMemberEntity> getMyProfile() async => CurrentMemberEntity(
+        memberId: 1,
+        email: 's24068@gsm.hs.kr',
+        name: '이찬진',
+        role: role,
+      );
+
+  // 나머지 멤버는 이 테스트에서 사용하지 않으므로 noSuchMethod로 위임한다.
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} not stubbed');
+}

--- a/test/unit/session_reissue_on_launch_unit_test.dart
+++ b/test/unit/session_reissue_on_launch_unit_test.dart
@@ -92,6 +92,37 @@ void main() {
       expect(container.read(currentMemberProvider).value?.role, RoleEnum.user);
     },
   );
+
+  test(
+    'refreshRole는 await 도중 세션이 종료되면 세션을 부활시키지 않는다 (#123)',
+    () async {
+      late final ProviderContainer container;
+      final repository = _FakeMemberRepository(
+        profileRole: RoleEnum.admin,
+        myRole: RoleEnum.user,
+        // getMyRole 응답 직전에 로그아웃(clear)이 일어난 상황을 재현한다.
+        onGetMyRole: () async {
+          container.read(currentMemberProvider.notifier).clear();
+        },
+      );
+
+      container = ProviderContainer(
+        overrides: [
+          memberRepositoryProvider.overrideWithValue(repository),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // 멤버를 먼저 로드해 상태를 채운다.
+      await container.read(currentMemberProvider.notifier).fetch();
+      expect(container.read(currentMemberProvider).value, isNotNull);
+
+      await container.read(currentMemberProvider.notifier).refreshRole();
+
+      // clear로 종료된 세션이 되살아나면 안 된다.
+      expect(container.read(currentMemberProvider).value, isNull);
+    },
+  );
 }
 
 class _RecordingSessionDataSource implements SessionRemoteDataSource {
@@ -118,10 +149,17 @@ class _RecordingSessionDataSource implements SessionRemoteDataSource {
 }
 
 class _FakeMemberRepository implements MemberRepository {
-  _FakeMemberRepository({required this.profileRole, required this.myRole});
+  _FakeMemberRepository({
+    required this.profileRole,
+    required this.myRole,
+    this.onGetMyRole,
+  });
 
   final RoleEnum profileRole;
   final RoleEnum myRole;
+
+  /// getMyRole의 await 도중 상태를 바꾸기 위한 훅.
+  final Future<void> Function()? onGetMyRole;
 
   @override
   Future<CurrentMemberEntity> getMyProfile() async => CurrentMemberEntity(
@@ -132,7 +170,10 @@ class _FakeMemberRepository implements MemberRepository {
       );
 
   @override
-  Future<RoleEnum> getMyRole() async => myRole;
+  Future<RoleEnum> getMyRole() async {
+    await onGetMyRole?.call();
+    return myRole;
+  }
 
   // 나머지 멤버는 이 테스트에서 사용하지 않으므로 noSuchMethod로 위임한다.
   @override

--- a/test/unit/session_reissue_on_launch_unit_test.dart
+++ b/test/unit/session_reissue_on_launch_unit_test.dart
@@ -10,6 +10,7 @@ import 'package:goms/features/auth/session/presentation/viewmodels/session_viewm
 import 'package:goms/features/member/data/providers/member_providers.dart';
 import 'package:goms/features/member/domain/entities/current_member_entity.dart';
 import 'package:goms/features/member/domain/repositories/member_repository.dart';
+import 'package:goms/features/member/presentation/providers/current_member_provider.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -65,7 +66,11 @@ void main() {
       storage['refresh_token_expiry'] = future.toIso8601String();
 
       final session = _RecordingSessionDataSource();
-      final repository = _FakeMemberRepository(role: RoleEnum.user);
+      // 프로필은 stale(admin=학생회), /myrole은 서버 DB 기준 최신(user=학생).
+      final repository = _FakeMemberRepository(
+        profileRole: RoleEnum.admin,
+        myRole: RoleEnum.user,
+      );
 
       final container = ProviderContainer(
         overrides: [
@@ -82,8 +87,9 @@ void main() {
       expect(session.reissueCalls, 1);
       expect(storage['access_token'], 'renewed-access-token');
       expect(storage['refresh_token'], 'renewed-refresh-token');
-      // 최신 role이 반영된다.
       expect(container.read(authProvider), AuthStatus.authenticated);
+      // /myrole 값으로 stale 권한이 보정되어야 한다.
+      expect(container.read(currentMemberProvider).value?.role, RoleEnum.user);
     },
   );
 }
@@ -112,17 +118,21 @@ class _RecordingSessionDataSource implements SessionRemoteDataSource {
 }
 
 class _FakeMemberRepository implements MemberRepository {
-  _FakeMemberRepository({required this.role});
+  _FakeMemberRepository({required this.profileRole, required this.myRole});
 
-  final RoleEnum role;
+  final RoleEnum profileRole;
+  final RoleEnum myRole;
 
   @override
   Future<CurrentMemberEntity> getMyProfile() async => CurrentMemberEntity(
         memberId: 1,
         email: 's24068@gsm.hs.kr',
         name: '이찬진',
-        role: role,
+        role: profileRole,
       );
+
+  @override
+  Future<RoleEnum> getMyRole() async => myRole;
 
   // 나머지 멤버는 이 테스트에서 사용하지 않으므로 noSuchMethod로 위임한다.
   @override

--- a/test/unit/student_council_members_provider_unit_test.dart
+++ b/test/unit/student_council_members_provider_unit_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:goms/core/enums/role_enum.dart';
 import 'package:goms/features/home/domain/enums/student_role_enum.dart';
 import 'package:goms/features/member/data/providers/member_providers.dart';
 import 'package:goms/features/member/data/request/student_council_filter_request.dart';
@@ -148,6 +149,11 @@ class _FakeMemberRepository implements MemberRepository {
 
   @override
   Future<CurrentMemberEntity> getMyProfile() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<RoleEnum> getMyRole() {
     throw UnimplementedError();
   }
 }

--- a/test/widget/admin_outing_state_screen_widget_test.dart
+++ b/test/widget/admin_outing_state_screen_widget_test.dart
@@ -162,6 +162,11 @@ class _FakeMemberRepository implements MemberRepository {
   }
 
   @override
+  Future<RoleEnum> getMyRole() {
+    throw UnimplementedError();
+  }
+
+  @override
   Future<CurrentMemberEntity> getMyProfile() {
     throw UnimplementedError();
   }


### PR DESCRIPTION
## 💡 개요
학생회 디스코드 동기화 이후 일부 사용자에게 이전(학생회) 권한이 계속 보이던 문제를 수정한 **v1.4.3**을 배포합니다. develop을 main에 병합해 프로덕션 배포를 수행합니다. (CD가 이 머지에서 배포)

## 🔗 관련 이슈
Closes #123

## 📃 작업내용 (직전 릴리즈 대비 추가분)
- #124 동기화 후 stale 권한 문제 수정
  - 앱 실행 시 refresh token이 유효하면 access token 만료 여부와 무관하게 `reissue`를 먼저 호출해 role claim 최신화 (일시 장애 시 기존 access token 폴백 유지)
  - `/member/myrole`(서버 DB 기준)로 권한을 한 번 더 보정, `await` 이후 세션 부활 방지 가드 포함
- CI에서 중복 릴리즈 APK 빌드/업로드 스텝 제거 (c342701)
- 버전 `1.4.2+46` → `1.4.3+47`

## 🔍 테스트 방법
- 머지 시 Flutter CD 워크플로우가 analyze/test → AAB 빌드 → production 트랙 업로드 수행
- 학생회→학생 동기화 후 앱 재실행 시 학생 권한으로 정상 표시되는지 확인
- 전체 테스트 통과, `flutter analyze` 클린

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 기존 기능이 정상적으로 작동하는지 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
