### PR TITLE
🔀 :: v1.4.4 - 핫플레이스 조회 기준 기간 1일로 변경

### DIFF
--- a/.github/workflows/flutter-ci.yaml
+++ b/.github/workflows/flutter-ci.yaml
@@ -29,14 +29,9 @@ jobs:
         run: |
           mkdir -p assets/env
           {
-            echo "GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}"
-            echo "FIREBASE_ANDROID_APP_ID=${{ secrets.FIREBASE_ANDROID_APP_ID }}"
-            echo "FIREBASE_MESSAGING_SENDER_ID=${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}"
-            echo "FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}"
-            echo "FIREBASE_STORAGE_BUCKET=${{ secrets.FIREBASE_STORAGE_BUCKET }}"
-            echo "FIREBASE_IOS_API_KEY=${{ secrets.FIREBASE_IOS_API_KEY }}"
-            echo "FIREBASE_IOS_APP_ID=${{ secrets.FIREBASE_IOS_APP_ID }}"
-            echo "FIREBASE_IOS_BUNDLE_ID=${{ secrets.FIREBASE_IOS_BUNDLE_ID }}"
+            echo "GOMS_API_BASE_URL=${{ secrets.GOMS_API_BASE_URL }}"
+            echo "KAKAO_NATIVE_APP_KEY=${{ secrets.KAKAO_NATIVE_APP_KEY }}"
+            echo "KAKAO_REST_API_KEY=${{ secrets.KAKAO_REST_API_KEY }}"
           } > assets/env/dev.env
           cp assets/env/dev.env assets/env/prod.env
 

--- a/lib/features/map/discovery/presentation/providers/map_screen_provider.dart
+++ b/lib/features/map/discovery/presentation/providers/map_screen_provider.dart
@@ -19,7 +19,7 @@ final mapScreenProvider = NotifierProvider<MapScreenNotifier, MapScreenState>(
 final mapReentryRefreshSignalProvider = StateProvider<int>((ref) => 0);
 
 class MapScreenNotifier extends Notifier<MapScreenState> {
-  static const _hotPlaceDays = 3;
+  static const _hotPlaceDays = 1;
 
   @override
   MapScreenState build() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # Read more about Android versioning at https://developer.android.com/studio/publish/versioning
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.4.3+47
+version: 1.4.4+48
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## 개요
v1.4.4 릴리즈 PR입니다.

## 변경 사항
- 핫플레이스(인기 장소) 조회 API `days` 파라미터를 최근 3일 → **최근 1일**로 변경 (#126)
- 버전업: `1.4.3+47` → `1.4.4+48`

🤖 Generated with [Claude Code](https://claude.com/claude-code)