### PR TITLE
🔀 :: (#122) - QR 인식 실패 후 카메라 복귀 시 검은 화면으로 남던 문제 수정

### DIFF
--- a/lib/features/qr/presentation/screens/qr_scan_screen.dart
+++ b/lib/features/qr/presentation/screens/qr_scan_screen.dart
@@ -29,21 +29,27 @@ class _QrScanScreenState extends ConsumerState<QrScanScreen> {
   void initState() {
     super.initState();
     _qrScanSubscription = ref.listenManual<QrScanState>(qrScanProvider, (
-        previous,
-        next,
-        ) async {
+      previous,
+      next,
+    ) async {
       if (!mounted) return;
 
-      if (next.status == QrScanStatus.failure && next.errorMessage != null) {
-        await context.push(RoutePath.qrResultLocation('failure'));
-        if (mounted) context.pop();
-        return;
-      }
+      final resultLocation = switch (next.status) {
+        QrScanStatus.failure when next.errorMessage != null =>
+          RoutePath.qrResultLocation('failure'),
+        QrScanStatus.success when next.resultType != null =>
+          RoutePath.qrResultLocation(next.resultType!.name),
+        _ => null,
+      };
+      if (resultLocation == null) return;
 
-      if (next.status == QrScanStatus.success && next.resultType != null) {
-        await context.push(RoutePath.qrResultLocation(next.resultType!.name));
-        if (mounted) context.pop();
-      }
+      await context.push(resultLocation);
+
+      // 결과 화면이 닫히고 이 화면으로 돌아온 경우에만 여기에 도달한다.
+      // 결과 화면에서 홈으로 이동했다면 이 위젯은 이미 사라진 뒤다.
+      // _onDetect에서 멈춰둔 카메라를 다시 켜지 않으면 미리보기가 검은 채로 남는다.
+      if (!mounted) return;
+      await _controller.start();
     });
   }
 
@@ -199,13 +205,26 @@ Widget buildQrScanResultScreen(
   }
 }
 
+/// 결과 화면에서 스캔 화면으로 돌아간다.
+///
+/// `context.go(RoutePath.qr)`를 쓰면 go_router가 같은 pageKey로 `/qr`을 다시
+/// 매칭해 기존 State를 재사용하기 때문에 `initState`가 다시 돌지 않고,
+/// 멈춰둔 카메라가 그대로 남는다. 스택에 스캔 화면이 있으면 pop으로 돌아간다.
+void _backToScanner(BuildContext context) {
+  if (context.canPop()) {
+    context.pop();
+    return;
+  }
+  context.go(RoutePath.qr);
+}
+
 Widget buildQrScanResultRouteScreen(
     String? resultTypeName, {
       required BuildContext context,
     }) {
   if (resultTypeName == 'failure') {
     return OutingFailedScreen(
-      onRetryWithCamera: () => context.go(RoutePath.qr),
+      onRetryWithCamera: () => _backToScanner(context),
     );
   }
 
@@ -215,7 +234,7 @@ Widget buildQrScanResultRouteScreen(
 
   if (resultType == null) {
     return OutingFailedScreen(
-      onRetryWithCamera: () => context.go(RoutePath.qr),
+      onRetryWithCamera: () => _backToScanner(context),
     );
   }
 

--- a/lib/features/qr/presentation/screens/qr_scan_screen.dart
+++ b/lib/features/qr/presentation/screens/qr_scan_screen.dart
@@ -187,24 +187,6 @@ class _OverlayPainter extends CustomPainter {
       oldDelegate.scanRect != scanRect;
 }
 
-Widget buildQrScanResultScreen(
-    QrScanResultType resultType, {
-      required BuildContext context,
-    }) {
-  void goHome() => context.go(RoutePath.home);
-
-  switch (resultType) {
-    case QrScanResultType.outingStarted:
-      return OutingStartScreen(onConfirm: goHome);
-    case QrScanResultType.returnSuccess:
-      return ReturnSuccessScreen(onConfirm: goHome);
-    case QrScanResultType.lateReturn:
-      return LateScreen(onConfirm: goHome);
-    case QrScanResultType.cannotGoOut:
-      return CannotGoOutScreen(onGoHome: goHome);
-  }
-}
-
 /// 결과 화면에서 스캔 화면으로 돌아간다.
 ///
 /// `context.go(RoutePath.qr)`를 쓰면 go_router가 같은 pageKey로 `/qr`을 다시
@@ -218,25 +200,29 @@ void _backToScanner(BuildContext context) {
   context.go(RoutePath.qr);
 }
 
+/// `/qr/result/:resultType` 라우트가 그리는 화면.
+///
+/// 성공 결과는 [QrScanResultType]의 이름으로, 실패는 `failure`로 들어온다.
+/// 이름이 매칭되지 않는 값도 실패로 취급한다.
+///
+/// 성공은 홈으로, 실패는 스캔 화면으로 돌아간다.
 Widget buildQrScanResultRouteScreen(
-    String? resultTypeName, {
-      required BuildContext context,
-    }) {
-  if (resultTypeName == 'failure') {
-    return OutingFailedScreen(
-      onRetryWithCamera: () => _backToScanner(context),
-    );
-  }
+  String? resultTypeName, {
+  required BuildContext context,
+}) {
+  void goHome() => context.go(RoutePath.home);
 
   final resultType = QrScanResultType.values
       .where((type) => type.name == resultTypeName)
       .firstOrNull;
 
-  if (resultType == null) {
-    return OutingFailedScreen(
-      onRetryWithCamera: () => _backToScanner(context),
-    );
-  }
-
-  return buildQrScanResultScreen(resultType, context: context);
+  return switch (resultType) {
+    QrScanResultType.outingStarted => OutingStartScreen(onConfirm: goHome),
+    QrScanResultType.returnSuccess => ReturnSuccessScreen(onConfirm: goHome),
+    QrScanResultType.lateReturn => LateScreen(onConfirm: goHome),
+    QrScanResultType.cannotGoOut => CannotGoOutScreen(onGoHome: goHome),
+    null => OutingFailedScreen(
+        onRetryWithCamera: () => _backToScanner(context),
+      ),
+  };
 }

--- a/test/widget/qr_scan_return_to_camera_widget_test.dart
+++ b/test/widget/qr_scan_return_to_camera_widget_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:goms/app/router/route_path.dart';
+import 'package:goms/features/qr/presentation/screens/qr_scan_screen.dart';
+import 'package:responsive_framework/responsive_framework.dart';
+
+/// #122 회귀 테스트.
+///
+/// 실패 결과 화면의 "카메라로 돌아가기"가 `context.go(RoutePath.qr)`였을 때는
+/// 스택 전체가 `/qr` 하나로 교체돼, go_router가 같은 pageKey로 스캔 화면을
+/// 재사용하면서 `initState`가 다시 돌지 않았다. 멈춰둔 카메라도 그대로 남았다.
+/// 이제는 pop으로 돌아가므로 스캔 화면 아래의 라우트가 살아남아야 한다.
+void main() {
+  testWidgets('QR 실패 화면에서 카메라로 돌아가면 스캔 화면 아래 스택이 유지된다', (tester) async {
+    final router = GoRouter(
+      initialLocation: RoutePath.home,
+      routes: [
+        GoRoute(
+          path: RoutePath.home,
+          builder: (context, state) => const Scaffold(body: Text('home-screen')),
+        ),
+        GoRoute(
+          path: RoutePath.qr,
+          builder: (context, state) => const Scaffold(body: Text('scan-screen')),
+        ),
+        GoRoute(
+          path: RoutePath.qrResult,
+          builder: (context, state) => buildQrScanResultRouteScreen(
+            state.pathParameters['resultType'],
+            context: context,
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        builder: (context, child) => ResponsiveBreakpoints.builder(
+          child: child!,
+          breakpoints: const [
+            Breakpoint(start: 0, end: 359, name: 'SMALL_PHONE'),
+            Breakpoint(start: 360, end: 450, name: 'MOBILE'),
+            Breakpoint(start: 451, end: 800, name: 'TABLET'),
+            Breakpoint(start: 801, end: 1920, name: 'DESKTOP'),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 홈 -> 스캔 -> 실패 결과. 실제 흐름과 같이 둘 다 push로 쌓는다.
+    router.push(RoutePath.qr);
+    await tester.pumpAndSettle();
+    router.push(RoutePath.qrResultLocation('failure'));
+    await tester.pumpAndSettle();
+    expect(find.text('외출에 실패했어요..'), findsOneWidget);
+
+    await tester.tap(find.text('카메라로 돌아가기'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('scan-screen'), findsOneWidget);
+    // go로 교체됐다면 스택이 [/qr] 하나만 남아 canPop()이 false가 된다.
+    expect(router.canPop(), isTrue);
+  });
+
+  testWidgets('스캔 화면 없이 실패 화면에 바로 진입하면 스캔 화면으로 이동한다', (tester) async {
+    final router = GoRouter(
+      initialLocation: RoutePath.qrResultLocation('failure'),
+      routes: [
+        GoRoute(
+          path: RoutePath.qr,
+          builder: (context, state) => const Scaffold(body: Text('scan-screen')),
+        ),
+        GoRoute(
+          path: RoutePath.qrResult,
+          builder: (context, state) => buildQrScanResultRouteScreen(
+            state.pathParameters['resultType'],
+            context: context,
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        builder: (context, child) => ResponsiveBreakpoints.builder(
+          child: child!,
+          breakpoints: const [
+            Breakpoint(start: 0, end: 359, name: 'SMALL_PHONE'),
+            Breakpoint(start: 360, end: 450, name: 'MOBILE'),
+            Breakpoint(start: 451, end: 800, name: 'TABLET'),
+            Breakpoint(start: 801, end: 1920, name: 'DESKTOP'),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('카메라로 돌아가기'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('scan-screen'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 💡 개요

QR 인식 실패 후 "카메라로 돌아가기"를 누르면 화면이 검게 남고 다시 인식되지 않던 문제를 수정했습니다.

## 🔗 관련 이슈

Closes #122

## 📃 작업내용

### 원인

`_onDetect` 가 스캔을 감지하면 카메라를 멈추는데, 이걸 다시 켜는 코드가 없었습니다.

```dart
_controller.stop();
await ref.read(qrScanProvider.notifier).processScan(barcode.rawValue!);
```

`_controller.start()` 는 파일 어디에도 없었고, `initState` 에서 컨트롤러를 만들 때만 카메라가 돌았습니다.

실패 경로만 이걸 밟습니다.

1. 실패 → 리스너가 `await context.push('/qr/result/failure')`. **push라서 `QrScanScreen` 은 살아있습니다.**
2. "카메라로 돌아가기" → `context.go(RoutePath.qr)`
3. go_router 가 `/qr` 을 다시 매칭하는데 `state.pageKey` 가 같아서 **같은 Element·State 가 재사용**됩니다.
   `initState` 가 다시 돌지 않으니 컨트롤러는 멈춘 그대로 → 검은 화면

성공 경로는 결과 화면 버튼이 `context.go('/home')` 이라 `QrScanScreen` 이 언마운트되고,
다음 진입 때 State 가 새로 만들어져서 멀쩡했습니다. 그래서 실패 후 복귀에서만 재현됐습니다.

### 수정

**1. 결과 화면에서 돌아오면 카메라 재개**
```dart
await context.push(resultLocation);

// 결과 화면이 닫히고 이 화면으로 돌아온 경우에만 여기에 도달한다.
if (!mounted) return;
await _controller.start();
```
`DetectionSpeed.noDuplicates` 의 `lastScanned` 는 `start()` / `stop()` 양쪽에서 초기화되므로
(`MobileScanner.kt:396,594`) 같은 QR 을 다시 찍어도 정상 인식됩니다.

**2. 복귀를 `go` 대신 `pop` 으로**
`go` 는 스택 전체를 `/qr` 하나로 교체해서, 스캔 화면 아래에 있던 라우트가 사라집니다.
그래서 복귀 후 닫기 버튼을 눌러도 원래 화면으로 못 돌아갔습니다.
결과 화면에 딥링크로 바로 진입한 경우를 위해 `go` 폴백은 남겼습니다.

**3. 불필요한 `context.pop()` 제거**
성공/실패로 갈라져 있던 리스너를 하나로 합쳤습니다.
기존에는 `await push(...)` 뒤에 `if (mounted) context.pop();` 이 있어서,
2번 상황에서 스택에 `/qr` 하나만 남은 채로 pop 이 실행됐습니다.

## 🔍 테스트 방법

- `flutter analyze` → 0건
- `flutter test` → 142개 통과 (신규 2개 포함)
- 회귀 테스트 `test/widget/qr_scan_return_to_camera_widget_test.dart` 추가.
  수정 전 코드로 되돌리면 첫 번째 케이스가 실패하는 것을 확인했습니다.
- **기기 확인이 필요합니다.** 카메라 재개는 위젯 테스트로 검증할 수 없습니다.
  - QR 스캔 → 잘못된 QR 이나 서버 오류로 실패 → "카메라로 돌아가기"
    → 카메라 미리보기가 다시 보이는지
  - 이어서 **같은 QR** 을 다시 찍어도 인식되는지 (`noDuplicates` 영향 확인)
  - 복귀 후 좌측 상단 닫기(X) 버튼이 원래 화면으로 돌아가는지
  - 성공 경로(외출 시작 / 복귀 / 지각 / 외출불가)는 기존대로 홈으로 가는지

## 🙋‍♂️ 질문사항

- `_onDetect` 의 `_controller.stop()` 은 `await` 없이 호출되고 있습니다.
  이번 수정 범위에서는 건드리지 않았는데, 함께 정리할지 의견 주세요.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다. (카메라 동작은 기기 확인 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
